### PR TITLE
Crear script inicial de base de datos MySQL

### DIFF
--- a/database/README.md
+++ b/database/README.md
@@ -1,18 +1,96 @@
 # Base de datos VecinoSeguro
 
-Esta carpeta contiene los scripts iniciales de MySQL para el prototipo.
+Esta carpeta contiene los scripts iniciales de la base de datos MySQL del prototipo VecinoSeguro. La base se llama `vecino_seguro` y agrupa la información sobre roles, usuarios, emergencias e historial de cambios de estado.
 
-## Archivos
+## Contenido
 
-- `schema.sql`: crea tablas, claves primarias, claves foráneas e índices iniciales.
-- `seed.sql`: inserta datos de ejemplo seguros para pruebas locales.
+| Archivo | Propósito |
+|---------|-----------|
+| `schema.sql` | Crea la base de datos y las tablas principales con sus claves primarias, foráneas, índices y restricciones. |
+| `seed.sql` | Inserta datos de prueba para desarrollo y demostración (roles, usuarios, emergencias y un historial de ejemplo). |
+| `README.md` | Este archivo: explica el contenido y cómo ejecutar los scripts. |
 
-## Ejecución sugerida
+## Modelo de datos
+
+El esquema define cuatro tablas relacionadas:
+
+### `roles`
+Catálogo de roles del sistema. Por ahora se usan dos: `admin` y `vecino`.
+
+### `users`
+Usuarios del sistema. Cada usuario tiene un RUT único, correo, nombre completo, contraseña almacenada como hash y un rol asignado mediante `role_id`.
+
+### `emergencies`
+Emergencias reportadas por los vecinos. Cada emergencia tiene un tipo, descripción, ubicación, nivel de urgencia (`baja`, `media`, `alta`, `critica`) y estado del ciclo de vida (`pendiente`, `en_revision`, `resuelto`).
+
+### `emergency_status_history`
+Auditoría de los cambios de estado de cada emergencia. Permite saber quién cambió un estado, cuándo y opcionalmente con qué comentario.
+
+### Relaciones principales
+
+```
+roles (1) ──── (N) users
+users (1) ──── (N) emergencies
+emergencies (1) ──── (N) emergency_status_history
+users (1) ──── (N) emergency_status_history (changed_by)
+```
+
+## Cómo ejecutar los scripts
+
+Los scripts se ejecutan en orden: primero `schema.sql` (estructura), luego `seed.sql` (datos). Existen tres alternativas equivalentes según la herramienta que tengas instalada.
+
+### Opción A — Consola MySQL
+
+Desde la terminal, ubicado en la carpeta `database/`:
 
 ```bash
 mysql -u root -p < schema.sql
 mysql -u root -p vecino_seguro < seed.sql
 ```
 
-Los datos incluidos son solo ejemplos. Las contraseñas reales deben almacenarse siempre como hash seguro usando un algoritmo apropiado, nunca como texto plano.
+Reemplaza `root` por tu usuario si corresponde.
 
+### Opción B — MySQL Workbench
+
+1. Abre MySQL Workbench y conéctate a tu servidor local.
+2. Menú `File → Open SQL Script`, selecciona `schema.sql` y ejecútalo con el botón del rayo (`Ctrl + Shift + Enter`).
+3. Repite el proceso con `seed.sql`.
+
+### Opción C — phpMyAdmin (XAMPP, WAMP o Laragon)
+
+1. Inicia el servicio MySQL/MariaDB desde el panel de control.
+2. Abre `http://localhost/phpmyadmin` en el navegador.
+3. Pestaña `Importar`, selecciona `schema.sql` y ejecuta.
+4. Selecciona la base `vecino_seguro` desde el menú lateral.
+5. Pestaña `Importar` nuevamente, selecciona `seed.sql` y ejecuta.
+
+## Notas de arquitectura
+
+De acuerdo con `docs/arquitectura.md`, **únicamente el backend FastAPI se conecta directamente a MySQL**. La aplicación desktop (PySide6) y la aplicación móvil (Expo + React Native) consumen los datos a través de la API HTTP del backend, no acceden directamente a la base de datos.
+
+Este principio mantiene la lógica de negocio centralizada y evita que cada cliente tenga que conocer el esquema de datos.
+
+## Notas de seguridad
+
+- **Todos los datos del seed son ficticios.** RUTs, nombres, correos y direcciones son inventados solo para demostración.
+- **Las contraseñas se almacenan como hash**, nunca en texto plano. Los hashes incluidos en `seed.sql` son valores de ejemplo identificables y **no representan contraseñas reales**.
+- En producción, las contraseñas deben generarse con un algoritmo de hash seguro como **bcrypt** o **argon2**, incluyendo un `salt` único por contraseña.
+- **Nunca incluir credenciales reales en el repositorio**: ni en `seed.sql`, ni en archivos `.env` versionados.
+
+## Compatibilidad
+
+| Aspecto | Valor |
+|---------|-------|
+| Motor de base de datos | MySQL 8.0+ (recomendado) |
+| Compatible con | MariaDB 10.4+ (probado en XAMPP) |
+| Charset | `utf8mb4` |
+| Cotejamiento | `utf8mb4_unicode_ci` |
+| Motor de almacenamiento | `InnoDB` (requerido para soportar claves foráneas) |
+
+## Estructura para iteraciones futuras
+
+Si en iteraciones posteriores se requieren consultas de ejemplo, vistas o procedimientos almacenados, conviene agregar archivos complementarios manteniendo la convención de nombres en inglés:
+
+- `queries_examples.sql` — consultas frecuentes documentadas
+- `views.sql` — vistas para reportes
+- `procedures.sql` — procedimientos almacenados

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -1,58 +1,91 @@
--- Script inicial de esquema para VecinoSeguro.
--- Crea una base de datos MySQL y tablas principales para usuarios, roles y emergencias.
+-- =============================================================================
+-- VecinoSeguro - Esquema inicial de base de datos
+-- =============================================================================
+-- Archivo:      schema.sql
+-- Propósito:    Crea la base de datos del prototipo y las tablas principales
+--               para roles, usuarios, emergencias e historial de estados.
+-- Compatible:   MySQL 8.x y MariaDB 10.4+
+-- Charset:      utf8mb4 (Unicode completo, soporta acentos y emojis)
+-- Cotejamiento: utf8mb4_unicode_ci (case-insensitive, adecuado para español)
+-- Autor:        Equipo VecinoSeguro
+-- =============================================================================
 
+-- -----------------------------------------------------------------------------
+-- 1. Crear y seleccionar la base de datos
+-- -----------------------------------------------------------------------------
 CREATE DATABASE IF NOT EXISTS vecino_seguro
   CHARACTER SET utf8mb4
   COLLATE utf8mb4_unicode_ci;
 
 USE vecino_seguro;
 
--- Roles básicos del sistema, por ejemplo administrador y vecino.
+-- -----------------------------------------------------------------------------
+-- 2. Tabla `roles`
+--    Define los roles del sistema. Por ejemplo: admin, vecino.
+-- -----------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS roles (
-  id INT AUTO_INCREMENT PRIMARY KEY,
-  name VARCHAR(50) NOT NULL UNIQUE
-);
+  id          INT AUTO_INCREMENT PRIMARY KEY,
+  name        VARCHAR(50)  NOT NULL UNIQUE COMMENT 'Identificador único del rol',
+  description VARCHAR(255) NULL            COMMENT 'Descripción del rol y sus responsabilidades',
+  created_at  TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- Usuarios del sistema. La contraseña se almacena como hash, nunca en texto plano.
+-- -----------------------------------------------------------------------------
+-- 3. Tabla `users`
+--    Usuarios del sistema. La contraseña se almacena siempre como hash,
+--    nunca en texto plano. RUT y email son únicos.
+-- -----------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS users (
-  id INT AUTO_INCREMENT PRIMARY KEY,
-  rut VARCHAR(12) NOT NULL UNIQUE,
-  full_name VARCHAR(150) NOT NULL,
-  email VARCHAR(150) NOT NULL UNIQUE,
-  password_hash VARCHAR(255) NOT NULL,
-  role_id INT NOT NULL,
-  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  id            INT AUTO_INCREMENT PRIMARY KEY,
+  rut           VARCHAR(12)  NOT NULL UNIQUE COMMENT 'RUT chileno con dígito verificador (formato 12345678-9)',
+  full_name     VARCHAR(150) NOT NULL        COMMENT 'Nombre completo del usuario',
+  email         VARCHAR(150) NOT NULL UNIQUE COMMENT 'Correo electrónico único',
+  password_hash VARCHAR(255) NOT NULL        COMMENT 'Hash seguro de la contraseña (bcrypt/argon2)',
+  role_id       INT          NOT NULL        COMMENT 'Rol asignado al usuario',
+  created_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   CONSTRAINT fk_users_roles
     FOREIGN KEY (role_id) REFERENCES roles(id)
     ON UPDATE CASCADE
     ON DELETE RESTRICT
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- Emergencias reportadas por vecinos.
+-- -----------------------------------------------------------------------------
+-- 4. Tabla `emergencies`
+--    Registra las emergencias reportadas por los vecinos. Mantiene el estado
+--    actual y el nivel de urgencia mediante ENUM para garantizar valores válidos.
+-- -----------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS emergencies (
-  id INT AUTO_INCREMENT PRIMARY KEY,
-  user_id INT NOT NULL,
-  type VARCHAR(80) NOT NULL,
-  description TEXT NOT NULL,
-  location VARCHAR(255) NOT NULL,
-  urgency_level ENUM('baja', 'media', 'alta', 'critica') NOT NULL DEFAULT 'media',
-  status ENUM('reportada', 'en_revision', 'en_proceso', 'resuelta', 'cancelada') NOT NULL DEFAULT 'reportada',
-  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
-  updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  id            INT AUTO_INCREMENT PRIMARY KEY,
+  user_id       INT          NOT NULL  COMMENT 'Usuario que creó la emergencia',
+  type          VARCHAR(80)  NOT NULL  COMMENT 'Tipo de emergencia (ej: incendio, robo, corte de luz)',
+  description   TEXT         NOT NULL  COMMENT 'Descripción detallada del evento',
+  location      VARCHAR(255) NOT NULL  COMMENT 'Ubicación o sector donde ocurre',
+  urgency_level ENUM('baja', 'media', 'alta', 'critica') NOT NULL DEFAULT 'media'
+                COMMENT 'Nivel de urgencia: baja, media, alta, critica',
+  status        ENUM('pendiente', 'en_revision', 'resuelto') NOT NULL DEFAULT 'pendiente'
+                COMMENT 'Estado del ciclo de vida: pendiente, en_revision, resuelto',
+  created_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  updated_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   CONSTRAINT fk_emergencies_users
     FOREIGN KEY (user_id) REFERENCES users(id)
     ON UPDATE CASCADE
     ON DELETE RESTRICT
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
--- Historial de cambios de estado para auditar el ciclo de vida de una emergencia.
+-- -----------------------------------------------------------------------------
+-- 5. Tabla `emergency_status_history`
+--    Audita los cambios de estado de cada emergencia. Permite saber quién
+--    cambió qué y cuándo, opcionalmente con un comentario explicativo.
+-- -----------------------------------------------------------------------------
 CREATE TABLE IF NOT EXISTS emergency_status_history (
-  id INT AUTO_INCREMENT PRIMARY KEY,
-  emergency_id INT NOT NULL,
-  previous_status VARCHAR(50),
-  new_status VARCHAR(50) NOT NULL,
-  changed_by INT NOT NULL,
-  changed_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  id              INT AUTO_INCREMENT PRIMARY KEY,
+  emergency_id    INT          NOT NULL  COMMENT 'Emergencia afectada',
+  previous_status VARCHAR(50)  NULL      COMMENT 'Estado anterior (NULL en el primer registro)',
+  new_status      VARCHAR(50)  NOT NULL  COMMENT 'Estado nuevo aplicado',
+  changed_by      INT          NOT NULL  COMMENT 'Usuario que realizó el cambio',
+  changed_at      TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
+  comment         TEXT         NULL      COMMENT 'Comentario opcional asociado al cambio',
   CONSTRAINT fk_history_emergencies
     FOREIGN KEY (emergency_id) REFERENCES emergencies(id)
     ON UPDATE CASCADE
@@ -61,11 +94,23 @@ CREATE TABLE IF NOT EXISTS emergency_status_history (
     FOREIGN KEY (changed_by) REFERENCES users(id)
     ON UPDATE CASCADE
     ON DELETE RESTRICT
-);
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
 
-CREATE INDEX idx_users_role_id ON users(role_id);
-CREATE INDEX idx_emergencies_user_id ON emergencies(user_id);
-CREATE INDEX idx_emergencies_status ON emergencies(status);
-CREATE INDEX idx_emergencies_urgency_level ON emergencies(urgency_level);
-CREATE INDEX idx_history_emergency_id ON emergency_status_history(emergency_id);
+-- -----------------------------------------------------------------------------
+-- 6. Índices secundarios para consultas frecuentes
+--    Las claves foráneas crean su propio índice automáticamente, pero estos
+--    índices adicionales optimizan filtros comunes como listar por estado,
+--    ordenar por fecha de creación o auditar cambios por usuario.
+-- -----------------------------------------------------------------------------
+CREATE INDEX idx_users_role_id              ON users(role_id);
+CREATE INDEX idx_emergencies_user_id        ON emergencies(user_id);
+CREATE INDEX idx_emergencies_status         ON emergencies(status);
+CREATE INDEX idx_emergencies_urgency_level  ON emergencies(urgency_level);
+CREATE INDEX idx_emergencies_created_at     ON emergencies(created_at);
+CREATE INDEX idx_history_emergency_id       ON emergency_status_history(emergency_id);
+CREATE INDEX idx_history_changed_by         ON emergency_status_history(changed_by);
+
+-- =============================================================================
+-- Fin del script schema.sql
+-- =============================================================================
 

--- a/database/seed.sql
+++ b/database/seed.sql
@@ -1,26 +1,95 @@
--- Datos iniciales de ejemplo para VecinoSeguro.
--- Los password_hash son ficticios y no corresponden a contraseñas reales.
+-- =============================================================================
+-- VecinoSeguro - Datos iniciales de prueba
+-- =============================================================================
+-- Archivo:      seed.sql
+-- Propósito:    Insertar datos de ejemplo para desarrollo y demostración.
+-- Importante:   Todos los datos son ficticios. Las contraseñas se muestran
+--               como hashes de ejemplo y no deben usarse en ningún entorno
+--               real. En producción deben generarse con bcrypt o argon2.
+-- =============================================================================
 
 USE vecino_seguro;
 
-INSERT INTO roles (name)
-VALUES ('admin'), ('vecino')
-ON DUPLICATE KEY UPDATE name = VALUES(name);
-
+-- -----------------------------------------------------------------------------
+-- 1. Roles iniciales del sistema
+--    Las descripciones se mantienen alineadas con docs/requerimientos.md.
+-- -----------------------------------------------------------------------------
+INSERT INTO roles (name, description)
+VALUES
+  ('admin',  'Gestiona reportes, revisa estados y consulta resúmenes.'),
+  ('vecino', 'Reporta emergencias y revisa estados.')
+ON DUPLICATE KEY UPDATE description = VALUES(description);
+-- -----------------------------------------------------------------------------
+-- 2. Usuarios de ejemplo
+--    RUT con formato chileno válido (algoritmo módulo 11).
+--    password_hash es un valor ficticio identificable. NO usar en producción.
+-- -----------------------------------------------------------------------------
 INSERT INTO users (rut, full_name, email, password_hash, role_id)
 VALUES
-  ('11111111-1', 'Administradora Vecinal', 'admin@example.com', 'hash_ficticio_admin_no_usar', 1),
-  ('22222222-2', 'Vecino de Ejemplo', 'vecino@example.com', 'hash_ficticio_vecino_no_usar', 2)
+  ('11111111-1',
+   'Administradora Vecinal',
+   'admin@vecinoseguro.cl',
+   '$2b$12$ficticio.admin.no.usar.en.produccion.AAAAAAAAAAAAAAA',
+   1),
+  ('22222222-2',
+   'Carlos Pérez Soto',
+   'carlos.perez@vecinoseguro.cl',
+   '$2b$12$ficticio.vecino1.no.usar.en.produccion.BBBBBBBBBBBBB',
+   2),
+  ('13456789-9',
+   'María González Rojas',
+   'maria.gonzalez@vecinoseguro.cl',
+   '$2b$12$ficticio.vecino2.no.usar.en.produccion.CCCCCCCCCCCCC',
+   2)
 ON DUPLICATE KEY UPDATE full_name = VALUES(full_name);
 
+-- -----------------------------------------------------------------------------
+-- 3. Emergencias de ejemplo
+--    Cubren distintos tipos, niveles de urgencia y estados para demostrar
+--    el flujo completo del sistema durante las pruebas y la demo.
+-- -----------------------------------------------------------------------------
 INSERT INTO emergencies (user_id, type, description, location, urgency_level, status)
 VALUES
-  (2, 'Incendio', 'Humo visible cerca de una vivienda. Ejemplo para pruebas.', 'Pasaje Los Alerces 123', 'alta', 'reportada'),
-  (2, 'Corte de luz', 'Sector sin suministro eléctrico. Ejemplo para pruebas.', 'Plaza Central', 'media', 'en_revision');
+  (2, 'Incendio',
+      'Humo visible cerca de una vivienda. Vecinos reportan llamas en el techo.',
+      'Pasaje Los Alerces 123, Villa El Bosque',
+      'alta',    'pendiente'),
+  (2, 'Corte de luz',
+      'Sector completo sin suministro eléctrico desde hace dos horas.',
+      'Plaza Central, frente a la Junta de Vecinos',
+      'media',   'en_revision'),
+  (3, 'Robo en proceso',
+      'Persona sospechosa ingresando a una vivienda deshabitada.',
+      'Avenida Los Robles 456, departamento 3B',
+      'critica', 'resuelto'),
+  (3, 'Inundación menor',
+      'Acumulación de agua en la vereda tras lluvia intensa.',
+      'Calle Las Camelias 78, frente al colegio',
+      'baja',    'pendiente');
 
-INSERT INTO emergency_status_history (emergency_id, previous_status, new_status, changed_by)
+-- -----------------------------------------------------------------------------
+-- 4. Historial de cambios de estado
+--    Refleja el ciclo de vida de las emergencias. La primera fila de cada
+--    emergencia tiene previous_status NULL (estado inicial al ser reportada).
+--    La emergencia 3 muestra el flujo completo: pendiente -> en_revision -> resuelto.
+-- -----------------------------------------------------------------------------
+INSERT INTO emergency_status_history (emergency_id, previous_status, new_status, changed_by, comment)
 VALUES
-  (1, NULL, 'reportada', 2),
-  (2, NULL, 'reportada', 2),
-  (2, 'reportada', 'en_revision', 1);
+  -- Emergencia 1: solo registro inicial
+  (1, NULL,          'pendiente',   2, 'Reporte inicial registrado por el vecino.'),
 
+  -- Emergencia 2: registro inicial y paso a revisión
+  (2, NULL,          'pendiente',   2, 'Reporte inicial registrado por el vecino.'),
+  (2, 'pendiente',   'en_revision', 1, 'Equipo administrativo tomó contacto con la empresa eléctrica.'),
+
+  -- Emergencia 3: ciclo completo
+  (3, NULL,          'pendiente',   3, 'Reporte inicial registrado por el vecino.'),
+  (3, 'pendiente',   'en_revision', 1, 'Carabineros notificados, en camino al lugar.'),
+  (3, 'en_revision', 'resuelto',    1, 'Situación controlada. Persona detenida y entregada a la autoridad.'),
+
+  -- Emergencia 4: solo registro inicial
+  (4, NULL,          'pendiente',   3, 'Reporte inicial registrado por el vecino.');
+
+-- =============================================================================
+-- Fin del script seed.sql
+-- =============================================================================


### PR DESCRIPTION
## Cambios realizados

- Se actualizó el script `schema.sql` con la estructura inicial de la base de datos MySQL.
- Se completaron las tablas `roles`, `users`, `emergencies` y `emergency_status_history` con sus claves primarias, foráneas, índices, restricciones únicas y comentarios SQL.
- Se ajustó el ENUM de `emergencies.status` a los 3 valores definidos en la Issue (`pendiente`, `en_revision`, `resuelto`).
- Se agregaron `description` y `created_at` a `roles`, `updated_at` a `users` y `comment` a `emergency_status_history`.
- Se actualizó el script `seed.sql` con datos de prueba: 2 roles, 1 admin y 2 vecinos, 4 emergencias con distintos tipos/estados/urgencias y 7 registros en historial.
- Se actualizó `database/README.md` con modelo de datos, tres formas de ejecutar los scripts (consola, MySQL Workbench y phpMyAdmin), notas de arquitectura y notas de seguridad.

## Issue relacionado

Closes #3

## Pruebas realizadas

- Se revisó la sintaxis SQL.
- Se ejecutó `schema.sql` en phpMyAdmin sobre MariaDB 10.4 (XAMPP), creando correctamente las 4 tablas con motor InnoDB y cotejamiento `utf8mb4_unicode_ci`.
- Se ejecutó `seed.sql` y se verificó que las tablas contienen los conteos esperados (roles: 2, users: 3, emergencies: 4, emergency_status_history: 7).
- Se verificó la integridad referencial mediante una consulta `JOIN` sobre `emergencies`, `users` y `roles`.
- Se verificó que no se incluyen contraseñas reales ni datos sensibles.
- Se confirmó que los cambios están todos dentro de la carpeta `database/`.

## Notas

- Charset y cotejamiento (`utf8mb4_unicode_ci`) elegidos para garantizar compatibilidad con MySQL 8 y MariaDB.
- El archivo opcional `queries_examples.sql` se deja para una iteración posterior, según lo conversado con Roberto.