### PR TITLE
Preparar capa móvil de emergencias para futura integración con API

### DIFF
--- a/mobile/src/screens/EmergencyFormScreen.tsx
+++ b/mobile/src/screens/EmergencyFormScreen.tsx
@@ -3,6 +3,7 @@ import { Pressable, StyleSheet, Text, TextInput, View } from "react-native";
 
 import { AppLayout } from "../components/AppLayout";
 import { PrimaryButton } from "../components/PrimaryButton";
+import { createEmergency } from "../services/emergencyService";
 import { colors, radii, shadows, spacing } from "../styles/theme";
 import type { UrgencyLevel } from "../types/emergency";
 
@@ -25,20 +26,36 @@ export function EmergencyFormScreen({ onBack }: EmergencyFormScreenProps) {
   const [urgencyLevel, setUrgencyLevel] = useState<UrgencyLevel>("medium");
   const [message, setMessage] = useState("");
   const [error, setError] = useState("");
+  const [isSubmitting, setIsSubmitting] = useState(false);
 
-  const handleSubmit = () => {
+  const handleSubmit = async () => {
     if (!type.trim() || !description.trim() || !location.trim()) {
       setMessage("");
       setError("Completa tipo, descripción y ubicación para registrar el reporte.");
       return;
     }
 
-    setError("");
-    setMessage("Emergencia registrada de forma simulada. La conexión real quedará para una futura iteración.");
-    setType("");
-    setDescription("");
-    setLocation("");
-    setUrgencyLevel("medium");
+    try {
+      setIsSubmitting(true);
+      await createEmergency({
+        type,
+        description,
+        location,
+        urgencyLevel,
+      });
+
+      setError("");
+      setMessage("Emergencia registrada de forma simulada. La conexión real quedará para una futura iteración.");
+      setType("");
+      setDescription("");
+      setLocation("");
+      setUrgencyLevel("medium");
+    } catch {
+      setMessage("");
+      setError("No fue posible registrar la emergencia simulada.");
+    } finally {
+      setIsSubmitting(false);
+    }
   };
 
   return (
@@ -104,7 +121,7 @@ export function EmergencyFormScreen({ onBack }: EmergencyFormScreenProps) {
         {error ? <Text style={styles.error}>{error}</Text> : null}
         {message ? <Text style={styles.success}>{message}</Text> : null}
 
-        <PrimaryButton label="Registrar emergencia" onPress={handleSubmit} />
+        <PrimaryButton disabled={isSubmitting} label="Registrar emergencia" onPress={handleSubmit} />
         <PrimaryButton label="Volver al inicio" onPress={onBack} variant="outline" />
       </View>
     </AppLayout>

--- a/mobile/src/screens/EmergencyListScreen.tsx
+++ b/mobile/src/screens/EmergencyListScreen.tsx
@@ -1,10 +1,12 @@
+import { useEffect, useState } from "react";
 import { StyleSheet, Text, View } from "react-native";
 
 import { AppLayout } from "../components/AppLayout";
 import { EmergencyCard } from "../components/EmergencyCard";
 import { PrimaryButton } from "../components/PrimaryButton";
-import { mockEmergencies } from "../data/mockEmergencies";
+import { getEmergencies } from "../services/emergencyService";
 import { colors, spacing } from "../styles/theme";
+import type { Emergency } from "../types/emergency";
 
 interface EmergencyListScreenProps {
   onBack: () => void;
@@ -12,6 +14,22 @@ interface EmergencyListScreenProps {
 }
 
 export function EmergencyListScreen({ onBack, onRegisterEmergency }: EmergencyListScreenProps) {
+  const [emergencies, setEmergencies] = useState<Emergency[]>([]);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    getEmergencies().then((items) => {
+      if (isMounted) {
+        setEmergencies(items);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
+
   return (
     <AppLayout
       subtitle="Listado inicial con datos simulados para presentar estados, urgencias y ubicaciones."
@@ -24,11 +42,11 @@ export function EmergencyListScreen({ onBack, onRegisterEmergency }: EmergencyLi
 
       <View style={styles.sectionHeader}>
         <Text style={styles.sectionTitle}>Reportes comunitarios</Text>
-        <Text style={styles.sectionSubtitle}>{mockEmergencies.length} reportes simulados disponibles.</Text>
+        <Text style={styles.sectionSubtitle}>{emergencies.length} reportes simulados disponibles.</Text>
       </View>
 
       <View style={styles.list}>
-        {mockEmergencies.map((emergency) => (
+        {emergencies.map((emergency) => (
           <EmergencyCard emergency={emergency} key={emergency.id} />
         ))}
       </View>

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -1,11 +1,12 @@
+import { useEffect, useState } from "react";
 import { StyleSheet, Text, View } from "react-native";
 
 import { AppLayout } from "../components/AppLayout";
 import { EmergencyCard } from "../components/EmergencyCard";
 import { PrimaryButton } from "../components/PrimaryButton";
-import { mockEmergencies } from "../data/mockEmergencies";
+import { getEmergencies } from "../services/emergencyService";
 import { colors, radii, shadows, spacing } from "../styles/theme";
-import type { EmergencyStatus } from "../types/emergency";
+import type { Emergency, EmergencyStatus } from "../types/emergency";
 
 interface HomeScreenProps {
   onLogout: () => void;
@@ -21,7 +22,22 @@ const summaryConfig: Array<{ label: string; status: EmergencyStatus; color: stri
 ];
 
 export function HomeScreen({ onLogout, onRegisterEmergency, onViewEmergencies }: HomeScreenProps) {
-  const latestEmergencies = mockEmergencies.slice(0, 3);
+  const [emergencies, setEmergencies] = useState<Emergency[]>([]);
+  const latestEmergencies = emergencies.slice(0, 3);
+
+  useEffect(() => {
+    let isMounted = true;
+
+    getEmergencies().then((items) => {
+      if (isMounted) {
+        setEmergencies(items);
+      }
+    });
+
+    return () => {
+      isMounted = false;
+    };
+  }, []);
 
   return (
     <AppLayout
@@ -35,7 +51,7 @@ export function HomeScreen({ onLogout, onRegisterEmergency, onViewEmergencies }:
 
       <View style={styles.summaryGrid}>
         {summaryConfig.map((item) => {
-          const count = mockEmergencies.filter((emergency) => emergency.status === item.status).length;
+          const count = emergencies.filter((emergency) => emergency.status === item.status).length;
 
           return (
             <View key={item.status} style={styles.summaryCard}>

--- a/mobile/src/services/emergencyService.ts
+++ b/mobile/src/services/emergencyService.ts
@@ -1,0 +1,33 @@
+import { mockEmergencies } from "../data/mockEmergencies";
+import type { CreateEmergencyInput, Emergency } from "../types/emergency";
+
+let emergencyStore: Emergency[] = [...mockEmergencies];
+
+const cloneEmergency = (emergency: Emergency): Emergency => ({ ...emergency });
+
+// Fuente temporal basada en mocks; preparada para reemplazarse por llamadas HTTP.
+export async function getEmergencies(): Promise<Emergency[]> {
+  return emergencyStore.map(cloneEmergency);
+}
+
+export async function getEmergencyById(id: string): Promise<Emergency | null> {
+  const emergency = emergencyStore.find((item) => item.id === id);
+
+  return emergency ? cloneEmergency(emergency) : null;
+}
+
+export async function createEmergency(input: CreateEmergencyInput): Promise<Emergency> {
+  const emergency: Emergency = {
+    id: `emg-${Date.now()}`,
+    type: input.type.trim(),
+    description: input.description.trim(),
+    location: input.location.trim(),
+    status: "pending",
+    urgencyLevel: input.urgencyLevel,
+    createdAt: new Date().toISOString(),
+  };
+
+  emergencyStore = [emergency, ...emergencyStore];
+
+  return cloneEmergency(emergency);
+}

--- a/mobile/src/types/emergency.ts
+++ b/mobile/src/types/emergency.ts
@@ -12,3 +12,10 @@ export interface Emergency {
   urgencyLevel: UrgencyLevel;
   createdAt: string;
 }
+
+export interface CreateEmergencyInput {
+  type: string;
+  description: string;
+  location: string;
+  urgencyLevel: UrgencyLevel;
+}


### PR DESCRIPTION
## Cambios realizados

- Se creó `mobile/src/services/emergencyService.ts`.
- Se agregó una capa de servicio para centralizar la lógica móvil de emergencias.
- Se implementó `getEmergencies()` usando datos simulados.
- Se implementó `getEmergencyById(id)` usando datos simulados.
- Se implementó `createEmergency(input)` con registro simulado.
- Se agregó el tipo `CreateEmergencyInput`.
- Se ajustó `HomeScreen.tsx` para obtener emergencias desde el servicio.
- Se ajustó `EmergencyListScreen.tsx` para obtener emergencias desde el servicio.
- Se ajustó `EmergencyFormScreen.tsx` para usar `createEmergency()`.
- Se mantuvo `mockEmergencies` como fuente temporal de datos.
- No se implementó conexión real con backend todavía.

## Issue relacionado

Closes #13 

## Pruebas realizadas

- Se ejecutó `npx tsc --noEmit` sin errores.
- Se verificó que no se modificaran dependencias.
- Se verificó que no se modificaran carpetas fuera de `mobile/`.
- Se verificó que no se creara `.env` real.

## Notas

Esta PR deja preparada la app móvil para una futura integración con el endpoint real:

```http
GET /api/v1/emergencies