### PR TITLE
Conectar backend FastAPI con MySQL y endpoint inicial de emergencias

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -46,6 +46,41 @@ Ejemplo de respuesta:
 
 Este endpoint permite verificar que la API está levantada correctamente.
 
+## Endpoint de emergencias
+
+```text
+GET /api/v1/emergencies
+```
+
+Devuelve el listado de emergencias almacenadas en MySQL, ordenadas por fecha de creación descendente.
+
+Ejemplo de respuesta:
+
+```json
+[
+  {
+    "id": 1,
+    "user_id": 2,
+    "type": "Incendio",
+    "description": "Humo visible cerca de una vivienda.",
+    "location": "Pasaje Los Alerces 123",
+    "urgency_level": "alta",
+    "status": "pendiente",
+    "created_at": "2026-05-04T00:00:00",
+    "updated_at": "2026-05-04T00:00:00"
+  }
+]
+```
+
+Antes de probar este endpoint, se debe:
+
+1. Crear la base con `database/schema.sql`.
+2. Cargar datos de prueba con `database/seed.sql`.
+3. Configurar `backend/.env` usando `backend/.env.example` como referencia.
+4. Ejecutar el backend con `uvicorn app.main.main:app --reload`.
+
+Si la base de datos no responde o la consulta falla, el endpoint retorna `500` con un mensaje genérico.
+
 ## Módulos preparados
 
 - `auth`: autenticación con RUT y contraseña.

--- a/backend/app/db/connection.py
+++ b/backend/app/db/connection.py
@@ -1,20 +1,46 @@
 """Conexión centralizada a MySQL.
 
-Este archivo deja preparada la creación del motor de SQLAlchemy. La conexión
-real se activará cuando existan repositorios y modelos persistentes.
+Este archivo expone dos puntos de acceso a la base de datos:
+
+* ``get_connection``: conexión directa con ``mysql.connector`` para los
+  repositorios actuales que ejecutan SQL plano.
+* ``create_database_engine``: motor de SQLAlchemy preparado para módulos
+  futuros que requieran un ORM o pool de conexiones más completo.
+
+Los módulos deben usar este archivo como única capa de acceso a MySQL para
+evitar conexiones dispersas en distintos puntos del backend.
 """
 
+import mysql.connector
+from mysql.connector.connection import MySQLConnection
 from sqlalchemy import create_engine
 from sqlalchemy.engine import Engine
 
 from app.config.settings import settings
 
 
+def get_connection() -> MySQLConnection:
+    """Crea y retorna una conexión a MySQL usando variables de entorno.
+
+    La conexión se construye con los datos definidos en ``.env`` y leídos
+    por ``settings``. El llamador es responsable de cerrarla con
+    ``connection.close()`` cuando termine de usarla.
+    """
+    return mysql.connector.connect(
+        host=settings.database_host,
+        port=settings.database_port,
+        database=settings.database_name,
+        user=settings.database_user,
+        password=settings.database_password,
+    )
+
+
 def create_database_engine() -> Engine:
     """Crea un motor SQLAlchemy para MySQL usando variables de entorno.
 
     La función no ejecuta consultas por sí sola. Los módulos de repositorio
-    deberán usar este punto central para evitar conexiones dispersas.
+    que requieran SQLAlchemy deberán usar este punto central para evitar
+    conexiones dispersas.
     """
     return create_engine(settings.database_url, pool_pre_ping=True)
 

--- a/backend/app/modules/emergencies/repository.py
+++ b/backend/app/modules/emergencies/repository.py
@@ -1,16 +1,48 @@
 """Repositorio de emergencias.
 
-Este módulo se conectará a MySQL para registrar incidentes, consultar estados
-y mantener separada la lógica de persistencia.
+Este módulo concentra el acceso a MySQL para la tabla ``emergencies``. La
+capa de servicio y la capa HTTP no deben construir consultas SQL por su
+cuenta: deben hacerlo siempre a través de este repositorio.
 """
 
+from app.db.connection import get_connection
 from app.modules.emergencies.schemas import EmergencySummary
 
 
 class EmergencyRepository:
-    """Repositorio inicial para emergencias."""
+    """Consulta emergencias almacenadas en MySQL."""
 
     def list_emergencies(self) -> list[EmergencySummary]:
-        """Placeholder sin emergencias persistidas todavía."""
-        return []
+        """Retorna todas las emergencias ordenadas por fecha descendente.
+
+        Cierra el cursor y la conexión incluso si la consulta falla, para
+        evitar fugas de conexiones cuando el endpoint reciba muchas
+        peticiones.
+        """
+        query = """
+            SELECT
+                id,
+                user_id,
+                type,
+                description,
+                location,
+                urgency_level,
+                status,
+                created_at,
+                updated_at
+            FROM emergencies
+            ORDER BY created_at DESC
+        """
+
+        connection = get_connection()
+        cursor = None
+        try:
+            cursor = connection.cursor(dictionary=True)
+            cursor.execute(query)
+            rows = cursor.fetchall()
+            return [EmergencySummary(**row) for row in rows]
+        finally:
+            if cursor is not None:
+                cursor.close()
+            connection.close()
 

--- a/backend/app/modules/emergencies/router.py
+++ b/backend/app/modules/emergencies/router.py
@@ -1,6 +1,10 @@
-"""Rutas base para reportes de emergencias."""
+"""Rutas HTTP para emergencias.
 
-from fastapi import APIRouter
+Este router solo coordina la entrada y salida HTTP. La lógica de negocio
+queda en ``EmergencyService`` y el acceso a datos en ``EmergencyRepository``.
+"""
+
+from fastapi import APIRouter, HTTPException
 
 from app.modules.emergencies.schemas import EmergencySummary
 from app.modules.emergencies.service import EmergencyService
@@ -11,6 +15,18 @@ emergency_service = EmergencyService()
 
 @router.get("/", response_model=list[EmergencySummary])
 def list_emergencies() -> list[EmergencySummary]:
-    """Ruta placeholder para consultar emergencias registradas."""
-    return emergency_service.list_emergencies()
+    """Lista emergencias registradas en MySQL.
+
+    Devuelve un arreglo JSON con las emergencias almacenadas, ordenadas por
+    fecha de creación descendente. Si la base de datos no responde o la
+    consulta falla, retorna ``500`` con un mensaje genérico para no exponer
+    detalles internos del servidor.
+    """
+    try:
+        return emergency_service.list_emergencies()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="No fue posible obtener las emergencias",
+        ) from exc
 

--- a/backend/app/modules/emergencies/schemas.py
+++ b/backend/app/modules/emergencies/schemas.py
@@ -1,18 +1,27 @@
 """Modelos Pydantic para emergencias."""
 
 from datetime import datetime
+from typing import Optional
 
 from pydantic import BaseModel
 
 
 class EmergencySummary(BaseModel):
-    """Resumen de una emergencia para listados y paneles."""
+    """Resumen de una emergencia para listados y paneles.
+
+    Representa la respuesta del endpoint ``GET /api/v1/emergencies`` con los
+    campos almacenados en la tabla ``emergencies`` de MySQL. El campo
+    ``updated_at`` es opcional porque puede ser ``NULL`` para registros muy
+    antiguos sin fecha de actualización.
+    """
 
     id: int
+    user_id: int
     type: str
     description: str
     location: str
     urgency_level: str
     status: str
     created_at: datetime
+    updated_at: Optional[datetime] = None
 


### PR DESCRIPTION
## Cambios realizados

- Se completó `backend/app/db/connection.py` agregando la función `get_connection()` con `mysql.connector`, manteniendo la función existente `create_database_engine()` para compatibilidad con SQLAlchemy futuro.
- Se completó el módulo `backend/app/modules/emergencies/`:
  - `schemas.py`: se agregaron los campos `user_id` y `updated_at` (opcional) al modelo `EmergencySummary`.
  - `repository.py`: se implementó `list_emergencies()` con consulta SQL real a la tabla `emergencies`, con cierre seguro de cursor y conexión.
  - `router.py`: se agregó manejo de errores con `HTTPException` para devolver `500` con un mensaje genérico si la consulta falla.
- Se mantuvo intacto `service.py` (su responsabilidad de delegar al repositorio ya era correcta).
- Se actualizó `backend/README.md` con la sección del nuevo endpoint y los prerrequisitos para probarlo.
- No se modificaron `desktop/`, `mobile/`, `database/`, ni otros módulos del backend.

## Issue relacionado

Closes #11

## Pruebas realizadas

- Se creó y activó el entorno virtual en `backend/.venv` con `python -m venv .venv`.
- Se instalaron dependencias con `pip install -r requirements.txt`.
- Se configuró `backend/.env` a partir de `backend/.env.example` con credenciales locales de XAMPP (MariaDB 10.4.32).
- Se levantó el backend con `uvicorn app.main.main:app --reload`.
- Se verificó `GET /health` → `200 OK`.
- Se verificó `GET /api/v1/emergencies/` → `200 OK` con las 4 emergencias del seed (con todos los campos: `id, user_id, type, description, location, urgency_level, status, created_at, updated_at`).
- Se verificó la conexión real a la base `vecino_seguro` mediante el endpoint.
- Se verificó que `backend/.env` y `backend/.venv/` NO aparecen en `git status` ni en el commit (cubiertos por `.gitignore`).
- Se verificó que `git status` muestra solo los 5 archivos esperados modificados.

## Notas

- Las emergencias del seed comparten `created_at` exacto, por lo que MySQL las devuelve por orden natural (ID ascendente) al haber empate en la cláusula `ORDER BY created_at DESC`. Es comportamiento correcto.
- El endpoint opcional `GET /api/v1/emergencies/{emergency_id}` se deja para una iteración posterior, manteniendo el alcance acotado al endpoint principal pedido por la Issue.