### PR TITLE
fix: ajustar integración desktop de emergencias reales

### DIFF
--- a/desktop/src/controllers/emergency_controller.py
+++ b/desktop/src/controllers/emergency_controller.py
@@ -34,6 +34,7 @@ class EmergencyController:
     ) -> None:
         self._repo = repository or EmergencyRepository()
         self._api = api_client
+        self.backend_error: str | None = None
 
     # ------------------------------------------------------------------
     # API base del stub original (firma compatible)
@@ -63,10 +64,25 @@ class EmergencyController:
     # API extendida para uso desde las vistas
     # ------------------------------------------------------------------
     def listar(self) -> list[Emergencia]:
+        self.backend_error = None
+
         if self._api is not None:
             datos = self._api.get_emergencies()
             if datos is not None:
-                return self._parsear_emergencias(datos)
+                emergencias = self._parsear_emergencias(datos)
+                if emergencias or datos == []:
+                    return emergencias
+
+                self.backend_error = (
+                    "El backend respondió, pero no se pudieron interpretar "
+                    "las emergencias recibidas."
+                )
+            else:
+                self.backend_error = (
+                    "No se pudo conectar con el backend. "
+                    "Verifica que el servidor esté encendido."
+                )
+
         return self._repo.list_all()
 
     def _parsear_emergencias(self, datos: list[dict]) -> list[Emergencia]:
@@ -87,14 +103,19 @@ class EmergencyController:
                     ),
                     rut_reportante=str(d.get("user_id", "")),
                     nombre_reportante=f"Usuario {d.get('user_id', '')}",
-                    fecha_reporte=datetime.fromisoformat(
-                        d.get("created_at", datetime.now().isoformat())
-                    ),
+                    fecha_reporte=self._parsear_fecha(d.get("created_at")),
                 )
                 resultado.append(emergencia)
             except Exception:
                 continue
         return resultado
+
+    def _parsear_fecha(self, valor: object) -> datetime:
+        if isinstance(valor, datetime):
+            return valor
+        if not valor:
+            return datetime.now()
+        return datetime.fromisoformat(str(valor).replace("Z", "+00:00"))
 
     def listar_por_estado(self, estado: EstadoEmergencia) -> list[Emergencia]:
         return self._repo.filter_by_estado(estado)
@@ -105,8 +126,24 @@ class EmergencyController:
     def obtener(self, emergencia_id: int) -> Optional[Emergencia]:
         return self._repo.find_by_id(emergencia_id)
 
-    def estadisticas(self) -> dict[EstadoEmergencia, int]:
-        return self._repo.count_by_estado()
+    def estadisticas(
+        self, emergencias: list[Emergencia] | None = None
+    ) -> dict[EstadoEmergencia, int]:
+        datos = emergencias if emergencias is not None else self.listar()
+        return {
+            EstadoEmergencia.PENDIENTE: sum(
+                1 for e in datos if e.estado == EstadoEmergencia.PENDIENTE
+            ),
+            EstadoEmergencia.EN_REVISION: sum(
+                1 for e in datos if e.estado == EstadoEmergencia.EN_REVISION
+            ),
+            EstadoEmergencia.ATENDIDO: sum(
+                1 for e in datos if e.estado == EstadoEmergencia.ATENDIDO
+            ),
+            EstadoEmergencia.RESUELTO: sum(
+                1 for e in datos if e.estado == EstadoEmergencia.RESUELTO
+            ),
+        }
 
     def registrar(
         self,

--- a/desktop/src/models/entities.py
+++ b/desktop/src/models/entities.py
@@ -7,6 +7,7 @@ Se utilizan dataclasses para mantener los modelos simples, serializables
 y fáciles de mapear a/desde JSON cuando el backend FastAPI esté disponible.
 """
 
+import unicodedata
 from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from enum import Enum
@@ -16,19 +17,23 @@ from typing import TypeVar
 EnumT = TypeVar("EnumT", bound=Enum)
 
 
+def normalizar_texto(valor: str) -> str:
+    """Normaliza texto para comparar enums con o sin tildes, espacios o guiones."""
+    texto = valor.strip().replace("_", " ").lower()
+    texto = unicodedata.normalize("NFD", texto)
+    return "".join(c for c in texto if unicodedata.category(c) != "Mn")
+
+
 def normalizar_enum(valor: EnumT | str, enum_cls: type[EnumT], campo: str) -> EnumT:
     """Convierte strings válidos al enum esperado y rechaza valores inválidos."""
     if isinstance(valor, enum_cls):
         return valor
     if isinstance(valor, str):
-        texto = valor.strip()
+        texto = normalizar_texto(valor)
         for miembro in enum_cls:
-            if (
-                texto == miembro.value
-                or texto == miembro.name
-                or texto.lower() == miembro.value.lower()
-                or texto.lower() == miembro.name.lower()
-                or texto.replace("_", " ").lower() == miembro.value.lower()
+            if texto in (
+                normalizar_texto(miembro.value),
+                normalizar_texto(miembro.name),
             ):
                 return miembro
     raise ValueError(f"{campo} inválido: {valor!r}")
@@ -44,6 +49,8 @@ class TipoEmergencia(str, Enum):
     ACCIDENTE = "Accidente"
     INCENDIO = "Incendio"
     ROBO = "Robo"
+    ROBO_EN_PROCESO = "Robo en proceso"
+    INUNDACION_MENOR = "Inundación menor"
     PERSONA_EXTRAVIADA = "Persona extraviada"
     EMERGENCIA_MEDICA = "Emergencia médica"
     SOLICITUD_AYUDA = "Solicitud de ayuda"

--- a/desktop/src/views/dashboard_view.py
+++ b/desktop/src/views/dashboard_view.py
@@ -260,8 +260,9 @@ class DashboardView(QWidget):
 
     def refrescar(self) -> None:
         self.lbl_error_backend.setVisible(False)
-        
-        stats = self._controller.estadisticas()
+
+        emergencias = self._controller.listar()
+        stats = self._controller.estadisticas(emergencias)
         self.kpi_pendientes[1].setText(str(stats[EstadoEmergencia.PENDIENTE]))
         self.kpi_revision[1].setText(str(stats[EstadoEmergencia.EN_REVISION]))
         self.kpi_atendidos[1].setText(str(stats[EstadoEmergencia.ATENDIDO]))
@@ -273,17 +274,11 @@ class DashboardView(QWidget):
             if item.widget():
                 item.widget().deleteLater()
 
-        recientes = self._controller.listar()[:4]
-        
-        # Verificar si el backend respondió revisando si hay datos o no
-        if self._controller._api is not None:
-            datos_backend = self._controller._api.get_emergencies()
-            if datos_backend is None:
-                self.lbl_error_backend.setText(
-                    "⚠️ No se pudo conectar con el backend. "
-                    "Verifica que el servidor esté encendido."
-                )
-                self.lbl_error_backend.setVisible(True)
+        recientes = emergencias[:4]
+
+        if self._controller.backend_error:
+            self.lbl_error_backend.setText(f"⚠️ {self._controller.backend_error}")
+            self.lbl_error_backend.setVisible(True)
 
         if not recientes:
             vacio = QLabel("No hay reportes aún.")


### PR DESCRIPTION
## Resumen

Este PR ajusta la integración del dashboard desktop con el endpoint real de emergencias, manteniendo el trabajo base realizado en la Issue #20.

## Cambios realizados

- Se evita que `dashboard_view.py` acceda directamente a `_controller._api`.
- Se centraliza el mensaje de error del backend en `EmergencyController`.
- Se ajustan las estadísticas del dashboard para calcularse desde las emergencias listadas.
- Se mejora la normalización de enums para aceptar valores del backend con minúsculas, guiones bajos y tildes.
- Se agregan tipos de emergencia usados por los datos reales del backend.

## Alcance

Solo se modifican archivos dentro de `desktop/`.

## Restricciones respetadas

- No se modificó backend.
- No se modificó mobile.
- No se modificó database.
- No se crearon endpoints nuevos.
- No se agregaron archivos innecesarios.

## Pruebas realizadas

- [x] Backend levantado con Uvicorn.
- [x] Endpoint `/api/v1/emergencies/` probado en navegador.
- [x] App desktop ejecutada correctamente.
- [x] Login probado correctamente.
- [x] Dashboard probado con backend encendido.
- [x] Se verificó que no aparezca error cuando el backend responde.
- [x] Dashboard probado con backend apagado.
- [x] Se verificó que la app no se cae si el backend no responde.

## Contexto

Este PR corrige un detalle detectado después del merge del PR #23, donde el dashboard mostraba reportes pero también podía mostrar un mensaje de error de backend debido a una llamada directa desde la vista hacia el cliente API.