### PR TITLE
feat: add emergency catalogs and create endpoint

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -46,10 +46,10 @@ Ejemplo de respuesta:
 
 Este endpoint permite verificar que la API está levantada correctamente.
 
-## Endpoint de emergencias
+## Endpoints de emergencias
 
 ```text
-GET /api/v1/emergencies
+GET /api/v1/emergencies/
 ```
 
 Devuelve el listado de emergencias almacenadas en MySQL, ordenadas por fecha de creación descendente.
@@ -80,6 +80,68 @@ Antes de probar este endpoint, se debe:
 4. Ejecutar el backend con `uvicorn app.main.main:app --reload`.
 
 Si la base de datos no responde o la consulta falla, el endpoint retorna `500` con un mensaje genérico.
+
+```text
+GET /api/v1/emergencies/catalogs
+```
+
+Devuelve catálogos fijos para formularios y filtros de emergencias. Este endpoint no consulta MySQL.
+
+Ejemplo de respuesta:
+
+```json
+{
+  "emergency_types": [
+    { "value": "robo", "label": "Robo" },
+    { "value": "incendio", "label": "Incendio" },
+    { "value": "accidente", "label": "Accidente" },
+    { "value": "emergencia_medica", "label": "Emergencia médica" },
+    { "value": "corte_luz", "label": "Corte de luz" },
+    { "value": "persona_extraviada", "label": "Persona extraviada" },
+    { "value": "solicitud_ayuda", "label": "Solicitud de ayuda" },
+    { "value": "otro", "label": "Otro" }
+  ],
+  "urgency_levels": [
+    { "value": "baja", "label": "Baja" },
+    { "value": "media", "label": "Media" },
+    { "value": "alta", "label": "Alta" },
+    { "value": "critica", "label": "Crítica" }
+  ],
+  "statuses": [
+    { "value": "pendiente", "label": "Pendiente" },
+    { "value": "en_revision", "label": "En revisión" },
+    { "value": "resuelto", "label": "Resuelto" }
+  ]
+}
+```
+
+```text
+POST /api/v1/emergencies/
+```
+
+Crea una emergencia real en MySQL. El backend valida `type` y `urgency_level` contra los catálogos permitidos y asigna automáticamente `status = pendiente`.
+
+Body de ejemplo:
+
+```json
+{
+  "user_id": 2,
+  "type": "incendio",
+  "description": "Humo visible en una vivienda cercana",
+  "location": "Pasaje Los Aromos 123",
+  "urgency_level": "alta"
+}
+```
+
+Si la creación es correcta, responde `201 Created` con la emergencia creada, incluyendo `id`, `created_at` y `updated_at` generados por la base de datos.
+
+Para probar los endpoints desde Swagger:
+
+1. Ejecutar el backend con `uvicorn app.main.main:app --reload`.
+2. Abrir `http://127.0.0.1:8000/docs`.
+3. Probar `GET /api/v1/emergencies/catalogs`.
+4. Probar `POST /api/v1/emergencies/` con el body de ejemplo.
+5. Verificar que la nueva emergencia aparezca en `GET /api/v1/emergencies/`.
 
 ## Módulos preparados
 

--- a/backend/app/modules/emergencies/repository.py
+++ b/backend/app/modules/emergencies/repository.py
@@ -6,7 +6,7 @@ cuenta: deben hacerlo siempre a través de este repositorio.
 """
 
 from app.db.connection import get_connection
-from app.modules.emergencies.schemas import EmergencySummary
+from app.modules.emergencies.schemas import EmergencyCreate, EmergencySummary
 
 
 class EmergencyRepository:
@@ -41,6 +41,73 @@ class EmergencyRepository:
             cursor.execute(query)
             rows = cursor.fetchall()
             return [EmergencySummary(**row) for row in rows]
+        finally:
+            if cursor is not None:
+                cursor.close()
+            connection.close()
+
+    def create_emergency(
+        self,
+        emergency_data: EmergencyCreate,
+        status: str,
+    ) -> EmergencySummary:
+        """Inserta una emergencia y retorna el registro creado desde MySQL."""
+        insert_query = """
+            INSERT INTO emergencies (
+                user_id,
+                type,
+                description,
+                location,
+                urgency_level,
+                status
+            )
+            VALUES (%s, %s, %s, %s, %s, %s)
+        """
+        select_query = """
+            SELECT
+                id,
+                user_id,
+                type,
+                description,
+                location,
+                urgency_level,
+                status,
+                created_at,
+                updated_at
+            FROM emergencies
+            WHERE id = %s
+        """
+
+        connection = get_connection()
+        cursor = None
+        try:
+            cursor = connection.cursor(dictionary=True)
+            cursor.execute(
+                insert_query,
+                (
+                    emergency_data.user_id,
+                    emergency_data.type,
+                    emergency_data.description,
+                    emergency_data.location,
+                    emergency_data.urgency_level,
+                    status,
+                ),
+            )
+            connection.commit()
+
+            emergency_id = cursor.lastrowid
+            cursor.execute(select_query, (emergency_id,))
+            row = cursor.fetchone()
+            if row is None:
+                raise RuntimeError("No fue posible recuperar la emergencia creada")
+
+            return EmergencySummary(**row)
+        except Exception:
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            raise
         finally:
             if cursor is not None:
                 cursor.close()

--- a/backend/app/modules/emergencies/router.py
+++ b/backend/app/modules/emergencies/router.py
@@ -4,10 +4,17 @@ Este router solo coordina la entrada y salida HTTP. La lógica de negocio
 queda en ``EmergencyService`` y el acceso a datos en ``EmergencyRepository``.
 """
 
-from fastapi import APIRouter, HTTPException
+from fastapi import APIRouter, HTTPException, status
 
-from app.modules.emergencies.schemas import EmergencySummary
-from app.modules.emergencies.service import EmergencyService
+from app.modules.emergencies.schemas import (
+    EmergencyCatalogs,
+    EmergencyCreate,
+    EmergencySummary,
+)
+from app.modules.emergencies.service import (
+    EmergencyService,
+    EmergencyValidationError,
+)
 
 router = APIRouter()
 emergency_service = EmergencyService()
@@ -28,5 +35,29 @@ def list_emergencies() -> list[EmergencySummary]:
         raise HTTPException(
             status_code=500,
             detail="No fue posible obtener las emergencias",
+        ) from exc
+
+
+@router.get("/catalogs", response_model=EmergencyCatalogs)
+def get_emergency_catalogs() -> EmergencyCatalogs:
+    """Entrega catalogos fijos para formularios y filtros de emergencias."""
+    return emergency_service.get_catalogs()
+
+
+@router.post(
+    "/",
+    response_model=EmergencySummary,
+    status_code=status.HTTP_201_CREATED,
+)
+def create_emergency(emergency_data: EmergencyCreate) -> EmergencySummary:
+    """Crea una emergencia real en MySQL con estado inicial pendiente."""
+    try:
+        return emergency_service.create_emergency(emergency_data)
+    except EmergencyValidationError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="No fue posible crear la emergencia",
         ) from exc
 

--- a/backend/app/modules/emergencies/schemas.py
+++ b/backend/app/modules/emergencies/schemas.py
@@ -6,6 +6,31 @@ from typing import Optional
 from pydantic import BaseModel
 
 
+class CatalogOption(BaseModel):
+    """Opcion disponible en un catalogo usado por emergencias."""
+
+    value: str
+    label: str
+
+
+class EmergencyCatalogs(BaseModel):
+    """Catalogos fijos para formularios y filtros de emergencias."""
+
+    emergency_types: list[CatalogOption]
+    urgency_levels: list[CatalogOption]
+    statuses: list[CatalogOption]
+
+
+class EmergencyCreate(BaseModel):
+    """Datos requeridos para registrar una nueva emergencia."""
+
+    user_id: int
+    type: str
+    description: str
+    location: str
+    urgency_level: str
+
+
 class EmergencySummary(BaseModel):
     """Resumen de una emergencia para listados y paneles.
 

--- a/backend/app/modules/emergencies/service.py
+++ b/backend/app/modules/emergencies/service.py
@@ -1,7 +1,42 @@
 """Reglas de negocio para emergencias."""
 
 from app.modules.emergencies.repository import EmergencyRepository
-from app.modules.emergencies.schemas import EmergencySummary
+from app.modules.emergencies.schemas import (
+    EmergencyCatalogs,
+    EmergencyCreate,
+    EmergencySummary,
+)
+
+
+EMERGENCY_TYPES = [
+    {"value": "robo", "label": "Robo"},
+    {"value": "incendio", "label": "Incendio"},
+    {"value": "accidente", "label": "Accidente"},
+    {"value": "emergencia_medica", "label": "Emergencia médica"},
+    {"value": "corte_luz", "label": "Corte de luz"},
+    {"value": "persona_extraviada", "label": "Persona extraviada"},
+    {"value": "solicitud_ayuda", "label": "Solicitud de ayuda"},
+    {"value": "otro", "label": "Otro"},
+]
+
+URGENCY_LEVELS = [
+    {"value": "baja", "label": "Baja"},
+    {"value": "media", "label": "Media"},
+    {"value": "alta", "label": "Alta"},
+    {"value": "critica", "label": "Crítica"},
+]
+
+STATUSES = [
+    {"value": "pendiente", "label": "Pendiente"},
+    {"value": "en_revision", "label": "En revisión"},
+    {"value": "resuelto", "label": "Resuelto"},
+]
+
+INITIAL_STATUS = "pendiente"
+
+
+class EmergencyValidationError(ValueError):
+    """Error de validacion de reglas de negocio de emergencias."""
 
 
 class EmergencyService:
@@ -14,3 +49,49 @@ class EmergencyService:
         """Retorna emergencias desde el repositorio cuando exista persistencia."""
         return self.repository.list_emergencies()
 
+    def get_catalogs(self) -> EmergencyCatalogs:
+        """Retorna catalogos fijos sin consultar la base de datos."""
+        return EmergencyCatalogs(
+            emergency_types=EMERGENCY_TYPES,
+            urgency_levels=URGENCY_LEVELS,
+            statuses=STATUSES,
+        )
+
+    def create_emergency(
+        self,
+        emergency_data: EmergencyCreate,
+    ) -> EmergencySummary:
+        """Valida y registra una emergencia con estado inicial pendiente."""
+        self._validate_required_fields(emergency_data)
+        self._validate_catalog_values(emergency_data)
+
+        return self.repository.create_emergency(
+            emergency_data=emergency_data,
+            status=INITIAL_STATUS,
+        )
+
+    def _validate_required_fields(self, emergency_data: EmergencyCreate) -> None:
+        if emergency_data.user_id is None:
+            raise EmergencyValidationError("El usuario es obligatorio")
+
+        required_text_fields = {
+            "type": "El tipo de emergencia es obligatorio",
+            "description": "La descripcion es obligatoria",
+            "location": "La ubicacion es obligatoria",
+            "urgency_level": "El nivel de urgencia es obligatorio",
+        }
+
+        for field_name, message in required_text_fields.items():
+            value = getattr(emergency_data, field_name)
+            if not value or not value.strip():
+                raise EmergencyValidationError(message)
+
+    def _validate_catalog_values(self, emergency_data: EmergencyCreate) -> None:
+        valid_types = {option["value"] for option in EMERGENCY_TYPES}
+        valid_urgency_levels = {option["value"] for option in URGENCY_LEVELS}
+
+        if emergency_data.type not in valid_types:
+            raise EmergencyValidationError("El tipo de emergencia no es valido")
+
+        if emergency_data.urgency_level not in valid_urgency_levels:
+            raise EmergencyValidationError("El nivel de urgencia no es valido")


### PR DESCRIPTION
## Resumen

Este PR implementa los endpoints de catálogos y creación de emergencias dentro del módulo de emergencias del backend.

## Cambios realizados

- Se agregó `GET /api/v1/emergencies/catalogs`.
- Se agregaron catálogos fijos para tipos de emergencia, niveles de urgencia y estados.
- Se agregó `POST /api/v1/emergencies/`.
- Se valida `type` contra el catálogo permitido.
- Se valida `urgency_level` contra el catálogo permitido.
- Se asigna automáticamente `status = pendiente`.
- Se guarda la emergencia creada en MySQL/MariaDB.
- Se devuelve la emergencia creada como respuesta.
- Se actualizó `backend/README.md`.

## Pruebas realizadas

- [x] Backend levantado con `uvicorn app.main.main:app --reload`.
- [x] Swagger abierto en `http://127.0.0.1:8000/docs`.
- [x] Probado `GET /api/v1/emergencies/catalogs`.
- [x] Probado `POST /api/v1/emergencies/`.
- [x] Verificado que la emergencia creada aparece en `GET /api/v1/emergencies/`.
- [x] Ejecutado `python -m compileall app` sin errores.

## Alcance

Este PR modifica solo el módulo de emergencias del backend y el README del backend.

No modifica:

- `desktop/`
- `mobile/`
- `database/`
- `backend/app/modules/auth/`
- `backend/app/modules/users/`
- `backend/app/modules/reports/`
- `backend/app/db/connection.py`
- `backend/app/main/main.py`

## Issue relacionada

Closes #21 