### PR TITLE
Implementar endpoint de resumen para dashboard

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -154,3 +154,21 @@ Para probar los endpoints desde Swagger:
 
 Usa `.env.example` como referencia para crear un archivo `.env` local. No se deben versionar credenciales reales.
 
+
+## Endpoint de resumen para dashboard
+
+```text
+GET /api/v1/reports/summary
+```
+
+Entrega un resumen general de emergencias registradas en MySQL/MariaDB.
+
+La respuesta incluye:
+
+- Total de emergencias.
+- Conteo por estado.
+- Conteo por nivel de urgencia.
+
+Este endpoint es de solo lectura y está pensado para ser consumido posteriormente por el dashboard desktop o móvil.
+
+

--- a/backend/app/modules/reports/repository.py
+++ b/backend/app/modules/reports/repository.py
@@ -1,12 +1,62 @@
 """Repositorio para consultas agregadas y reportes."""
 
-from app.modules.reports.schemas import ReportSummary
+from app.db.connection import get_connection
 
 
 class ReportRepository:
-    """Repositorio inicial para estadísticas."""
+    """Repositorio para estadísticas y reportes."""
 
-    def get_summary(self) -> ReportSummary:
-        """Placeholder con contadores en cero hasta conectar MySQL."""
-        return ReportSummary(total_emergencies=0, open_emergencies=0, resolved_emergencies=0)
+    def get_total_emergencies(self) -> int:
+        """Obtiene el total de emergencias registradas."""
+        connection = get_connection()
+        cursor = connection.cursor()
 
+        query = "SELECT COUNT(*) FROM emergencies"
+        cursor.execute(query)
+
+        total = cursor.fetchone()[0]
+
+        cursor.close()
+        connection.close()
+
+        return total
+
+    def get_emergencies_by_status(self) -> dict[str, int]:
+        """Obtiene conteo de emergencias agrupadas por estado."""
+        connection = get_connection()
+        cursor = connection.cursor()
+
+        query = """
+            SELECT status, COUNT(*)
+            FROM emergencies
+            GROUP BY status
+        """
+
+        cursor.execute(query)
+
+        results = cursor.fetchall()
+
+        cursor.close()
+        connection.close()
+
+        return {status: count for status, count in results}
+
+    def get_emergencies_by_urgency(self) -> dict[str, int]:
+        """Obtiene conteo de emergencias agrupadas por urgencia."""
+        connection = get_connection()
+        cursor = connection.cursor()
+
+        query = """
+            SELECT urgency_level, COUNT(*)
+            FROM emergencies
+            GROUP BY urgency_level
+        """
+
+        cursor.execute(query)
+
+        results = cursor.fetchall()
+
+        cursor.close()
+        connection.close()
+
+        return {urgency: count for urgency, count in results}

--- a/backend/app/modules/reports/router.py
+++ b/backend/app/modules/reports/router.py
@@ -1,16 +1,15 @@
-"""Rutas base para reportes y métricas."""
+"""Rutas para reportes y métricas agregadas."""
 
 from fastapi import APIRouter
 
-from app.modules.reports.schemas import ReportSummary
+from app.modules.reports.schemas import ReportsSummaryResponse
 from app.modules.reports.service import ReportService
 
 router = APIRouter()
 report_service = ReportService()
 
 
-@router.get("/summary", response_model=ReportSummary)
-def get_summary() -> ReportSummary:
-    """Entrega un resumen inicial sin datos reales todavía."""
+@router.get("/summary", response_model=ReportsSummaryResponse)
+def get_summary() -> ReportsSummaryResponse:
+    """Entrega estadísticas agregadas de emergencias."""
     return report_service.get_summary()
-

--- a/backend/app/modules/reports/schemas.py
+++ b/backend/app/modules/reports/schemas.py
@@ -10,3 +10,10 @@ class ReportSummary(BaseModel):
     open_emergencies: int
     resolved_emergencies: int
 
+
+class ReportsSummaryResponse(BaseModel):
+    """Resumen general de emergencias para dashboard."""
+
+    total_emergencies: int
+    by_status: dict[str, int]
+    by_urgency: dict[str, int]

--- a/backend/app/modules/reports/service.py
+++ b/backend/app/modules/reports/service.py
@@ -1,20 +1,38 @@
-"""Servicio de reportes.
-
-Este módulo permitirá generar estadísticas y resúmenes de emergencias para
-usuarios administradores o paneles de monitoreo.
-"""
+"""Servicio de reportes y estadísticas agregadas."""
 
 from app.modules.reports.repository import ReportRepository
-from app.modules.reports.schemas import ReportSummary
+from app.modules.reports.schemas import ReportsSummaryResponse
 
 
 class ReportService:
-    """Coordina cálculos y consultas agregadas."""
+    """Coordina consultas y resúmenes estadísticos."""
+
+    VALID_STATUSES = ["pendiente", "en_revision", "resuelto"]
+    VALID_URGENCY_LEVELS = ["baja", "media", "alta", "critica"]
 
     def __init__(self) -> None:
         self.repository = ReportRepository()
 
-    def get_summary(self) -> ReportSummary:
-        """Retorna métricas iniciales desde el repositorio."""
-        return self.repository.get_summary()
+    def get_summary(self) -> ReportsSummaryResponse:
+        """Obtiene resumen agregado de emergencias."""
 
+        total_emergencies = self.repository.get_total_emergencies()
+
+        by_status = self.repository.get_emergencies_by_status()
+        by_urgency = self.repository.get_emergencies_by_urgency()
+
+        normalized_status = {
+            status: by_status.get(status, 0)
+            for status in self.VALID_STATUSES
+        }
+
+        normalized_urgency = {
+            urgency: by_urgency.get(urgency, 0)
+            for urgency in self.VALID_URGENCY_LEVELS
+        }
+
+        return ReportsSummaryResponse(
+            total_emergencies=total_emergencies,
+            by_status=normalized_status,
+            by_urgency=normalized_urgency,
+        )


### PR DESCRIPTION
## Descripción

Se implementa el endpoint de resumen para dashboard dentro del módulo de reportes del backend.

Endpoint implementado:

```http
GET /api/v1/reports/summary
```

## Cambios realizados

- Se agregó/actualizó el schema de respuesta para el resumen de reportes.
- Se agregó/actualizó el repository para consultar totales desde MySQL/MariaDB.
- Se agregó/actualizó el service para ordenar la respuesta del resumen.
- Se agregó/actualizó el router para exponer `/api/v1/reports/summary`.
- Se actualizó brevemente el README del backend.

## Pruebas realizadas

- Se levantó el backend con Uvicorn.
- Se revisó Swagger en `http://127.0.0.1:8000/docs`.
- Se probó `GET /api/v1/reports/summary`.
- Se compararon los resultados con la tabla `emergencies` desde MySQL/phpMyAdmin.
- Se verificó que `GET /api/v1/emergencies/` sigue funcionando.

## Alcance

No se modificó:

- `desktop/`
- `mobile/`
- `database/`
- `backend/app/modules/emergencies/`
- `backend/app/modules/auth/`
- `backend/app/modules/users/`
- `backend/app/db/connection.py`

Closes #19 
