### PR TITLE
feat: implement real login with RUT and password

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -143,6 +143,66 @@ Para probar los endpoints desde Swagger:
 4. Probar `POST /api/v1/emergencies/` con el body de ejemplo.
 5. Verificar que la nueva emergencia aparezca en `GET /api/v1/emergencies/`.
 
+## Login real con RUT y contraseña
+
+El backend autentica usuarios contra MySQL/MariaDB usando RUT chileno y contraseña bcrypt.
+
+Antes de probar el login:
+
+1. Instalar dependencias desde `backend/`.
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Configurar `backend/.env` usando `backend/.env.example` como referencia.
+3. Cargar la estructura de base de datos con `database/schema.sql`.
+4. Cargar datos ficticios de desarrollo con `database/seed.sql`.
+5. Ejecutar el backend desde `backend/`.
+   ```bash
+   uvicorn app.main.main:app --reload
+   ```
+
+Endpoint:
+
+```text
+POST /api/v1/auth/login
+```
+
+Body de prueba para usuario administrador:
+
+```json
+{
+  "rut": "11111111-1",
+  "password": "admin1234"
+}
+```
+
+Respuesta esperada:
+
+```json
+{
+  "success": true,
+  "message": "Login exitoso",
+  "user": {
+    "id": 1,
+    "rut": "11111111-1",
+    "full_name": "Administradora Vecinal",
+    "email": "admin@vecinoseguro.cl",
+    "role_id": 1
+  }
+}
+```
+
+También existe un usuario vecino de prueba:
+
+```json
+{
+  "rut": "22222222-2",
+  "password": "vecino1234"
+}
+```
+
+Estas credenciales son ficticias y solo sirven para desarrollo y demostración.
+
 ## Módulos preparados
 
 - `auth`: autenticación con RUT y contraseña.

--- a/backend/app/modules/auth/router.py
+++ b/backend/app/modules/auth/router.py
@@ -1,13 +1,13 @@
-"""Rutas base para autenticación.
-
-El login considera RUT y contraseña, pero todavía no consulta una base de datos
-real ni emite tokens definitivos.
-"""
+"""Rutas base para autenticación."""
 
 from fastapi import APIRouter, HTTPException, status
 
 from app.modules.auth.schemas import LoginRequest, LoginResponse
-from app.modules.auth.service import AuthService
+from app.modules.auth.service import (
+    AuthService,
+    InvalidCredentialsError,
+    InvalidLoginDataError,
+)
 
 router = APIRouter()
 auth_service = AuthService()
@@ -15,16 +15,21 @@ auth_service = AuthService()
 
 @router.post("/login", response_model=LoginResponse)
 def login(payload: LoginRequest) -> LoginResponse:
-    """Valida formato inicial de credenciales y deja preparado el login real."""
-    result = auth_service.validate_login_request(payload.rut, payload.password)
-    if not result:
+    """Autentica un usuario con RUT y contraseña."""
+    try:
+        return auth_service.login(payload.rut, payload.password)
+    except InvalidLoginDataError:
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail="RUT o contraseña con formato inválido.",
-        )
-
-    return LoginResponse(
-        message="Solicitud de login válida. Integración con base de datos pendiente.",
-        token=None,
-    )
-
+        ) from None
+    except InvalidCredentialsError:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail="RUT o contraseña incorrectos",
+        ) from None
+    except Exception:
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail="Error interno al procesar login.",
+        ) from None

--- a/backend/app/modules/auth/schemas.py
+++ b/backend/app/modules/auth/schemas.py
@@ -6,13 +6,23 @@ from pydantic import BaseModel, Field
 class LoginRequest(BaseModel):
     """Datos requeridos para iniciar sesión."""
 
-    rut: str = Field(..., examples=["12.345.678-5"])
-    password: str = Field(..., min_length=8, examples=["change_me_secure"])
+    rut: str = Field(..., examples=["11111111-1"])
+    password: str = Field(..., min_length=1, examples=["admin1234"])
+
+
+class AuthenticatedUser(BaseModel):
+    """Datos seguros del usuario autenticado."""
+
+    id: int
+    rut: str
+    full_name: str
+    email: str
+    role_id: int
 
 
 class LoginResponse(BaseModel):
-    """Respuesta inicial del flujo de login."""
+    """Respuesta segura del flujo de login."""
 
+    success: bool
     message: str
-    token: str | None = None
-
+    user: AuthenticatedUser

--- a/backend/app/modules/auth/service.py
+++ b/backend/app/modules/auth/service.py
@@ -1,16 +1,65 @@
-"""Servicio de autenticación.
+"""Servicio de autenticación."""
 
-Aquí se concentrará la lógica de validación, comparación de hash de contraseña
-y emisión de tokens cuando el prototipo avance.
-"""
+from passlib.context import CryptContext
+from passlib.exc import UnknownHashError
 
-from app.shared.validators.rut_validator import validate_rut
+from app.modules.auth.schemas import AuthenticatedUser, LoginResponse
+from app.modules.users.repository import UserRepository
+from app.shared.validators.rut_validator import normalize_rut, validate_rut
+
+
+pwd_context = CryptContext(schemes=["bcrypt"], deprecated="auto")
+
+
+class InvalidLoginDataError(Exception):
+    """Indica que los datos de login no tienen formato válido."""
+
+
+class InvalidCredentialsError(Exception):
+    """Indica que las credenciales no corresponden a un usuario válido."""
 
 
 class AuthService:
     """Servicio responsable de reglas de negocio del módulo de autenticación."""
 
+    def __init__(self) -> None:
+        self.user_repository = UserRepository()
+
     def validate_login_request(self, rut: str, password: str) -> bool:
         """Valida datos mínimos antes de intentar autenticar contra la base."""
-        return validate_rut(rut) and len(password.strip()) >= 8
+        return bool(rut and password and password.strip() and validate_rut(rut))
 
+    def login(self, rut: str, password: str) -> LoginResponse:
+        """Autentica un usuario por RUT y contraseña."""
+        if not self.validate_login_request(rut, password):
+            raise InvalidLoginDataError
+
+        normalized_rut = normalize_rut(rut)
+        user = self.user_repository.find_by_rut(normalized_rut)
+        if user is None:
+            raise InvalidCredentialsError
+
+        password_hash = user.get("password_hash")
+        if not password_hash:
+            raise InvalidCredentialsError
+
+        try:
+            password_matches = pwd_context.verify(password, password_hash)
+        except (UnknownHashError, ValueError, TypeError):
+            raise InvalidCredentialsError from None
+
+        if not password_matches:
+            raise InvalidCredentialsError
+
+        authenticated_user = AuthenticatedUser(
+            id=user["id"],
+            rut=user["rut"],
+            full_name=user["full_name"],
+            email=user["email"],
+            role_id=user["role_id"],
+        )
+        return LoginResponse(
+            success=True,
+            message="Login exitoso",
+            user=authenticated_user,
+        )

--- a/backend/app/modules/users/repository.py
+++ b/backend/app/modules/users/repository.py
@@ -4,6 +4,9 @@ Este archivo centralizará las operaciones de lectura y escritura de usuarios
 en MySQL para evitar que la lógica de base de datos se mezcle con rutas o servicios.
 """
 
+from typing import Any
+
+from app.db.connection import get_connection
 from app.modules.users.schemas import UserSummary
 
 
@@ -14,3 +17,29 @@ class UserRepository:
         """Placeholder sin datos persistentes todavía."""
         return []
 
+    def find_by_rut(self, rut: str) -> dict[str, Any] | None:
+        """Busca un usuario por RUT normalizado."""
+        query = """
+            SELECT
+                id,
+                rut,
+                full_name,
+                email,
+                password_hash,
+                role_id
+            FROM users
+            WHERE rut = %s
+            LIMIT 1
+        """
+        connection = None
+        cursor = None
+        try:
+            connection = get_connection()
+            cursor = connection.cursor(dictionary=True)
+            cursor.execute(query, (rut,))
+            return cursor.fetchone()
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if connection is not None:
+                connection.close()

--- a/backend/app/shared/validators/rut_validator.py
+++ b/backend/app/shared/validators/rut_validator.py
@@ -32,3 +32,15 @@ def validate_rut(rut: str) -> bool:
 
     return verifier == expected
 
+
+def format_rut(cleaned: str) -> str:
+    """Formatea un RUT limpio como 12345678-9."""
+    return f"{cleaned[:-1]}-{cleaned[-1]}"
+
+
+def normalize_rut(rut: str) -> str:
+    """Normaliza un RUT válido al formato usado por la base de datos."""
+    cleaned = clean_rut(rut)
+    if len(cleaned) < 2:
+        return ""
+    return format_rut(cleaned)

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -6,4 +6,5 @@ mysql-connector-python
 SQLAlchemy
 pytest
 httpx
-
+passlib[bcrypt]
+bcrypt==4.0.1

--- a/database/seed.sql
+++ b/database/seed.sql
@@ -3,9 +3,9 @@
 -- =============================================================================
 -- Archivo:      seed.sql
 -- Propósito:    Insertar datos de ejemplo para desarrollo y demostración.
--- Importante:   Todos los datos son ficticios. Las contraseñas se muestran
---               como hashes de ejemplo y no deben usarse en ningún entorno
---               real. En producción deben generarse con bcrypt o argon2.
+-- Importante:   Todos los datos son ficticios. Las credenciales documentadas
+--               son solo para desarrollo y demostración; no deben usarse en
+--               producción. En producción deben generarse hashes nuevos.
 -- =============================================================================
 
 USE vecino_seguro;
@@ -22,26 +22,32 @@ ON DUPLICATE KEY UPDATE description = VALUES(description);
 -- -----------------------------------------------------------------------------
 -- 2. Usuarios de ejemplo
 --    RUT con formato chileno válido (algoritmo módulo 11).
---    password_hash es un valor ficticio identificable. NO usar en producción.
+--    Credenciales ficticias para desarrollo y demostración:
+--      admin@vecinoseguro.cl -> admin1234
+--      carlos.perez@vecinoseguro.cl -> vecino1234
+--      maria.gonzalez@vecinoseguro.cl -> vecino1234
+--    password_hash contiene hashes bcrypt válidos. NO usar en producción.
 -- -----------------------------------------------------------------------------
 INSERT INTO users (rut, full_name, email, password_hash, role_id)
 VALUES
   ('11111111-1',
    'Administradora Vecinal',
    'admin@vecinoseguro.cl',
-   '$2b$12$ficticio.admin.no.usar.en.produccion.AAAAAAAAAAAAAAA',
+   '$2b$12$abcdefghijklmnopqrstuuQGuv7JMXhF88lMrtF64dVMmrFWSg9Hy',
    1),
   ('22222222-2',
    'Carlos Pérez Soto',
    'carlos.perez@vecinoseguro.cl',
-   '$2b$12$ficticio.vecino1.no.usar.en.produccion.BBBBBBBBBBBBB',
+   '$2b$12$abcdefghijklmnopqrstuut5sNDb4knLOg6.NM2MEDpS74Bo24SPG',
    2),
   ('13456789-9',
    'María González Rojas',
    'maria.gonzalez@vecinoseguro.cl',
-   '$2b$12$ficticio.vecino2.no.usar.en.produccion.CCCCCCCCCCCCC',
+   '$2b$12$abcdefghijklmnopqrstuut5sNDb4knLOg6.NM2MEDpS74Bo24SPG',
    2)
-ON DUPLICATE KEY UPDATE full_name = VALUES(full_name);
+ON DUPLICATE KEY UPDATE
+  full_name = VALUES(full_name),
+  password_hash = VALUES(password_hash);
 
 -- -----------------------------------------------------------------------------
 -- 3. Emergencias de ejemplo


### PR DESCRIPTION
## Descripción

Se implementa login real en el backend usando RUT y contraseña contra la tabla `users` de MySQL/MariaDB.

## Cambios realizados

- Se reemplazó el login provisorio por autenticación real.
- Se agregó búsqueda de usuario por RUT desde MySQL.
- Se agregó normalización de RUT para consultar en el formato almacenado.
- Se valida RUT chileno mediante módulo 11.
- Se verifica contraseña contra `password_hash` usando `passlib[bcrypt]`.
- Se fijó `bcrypt==4.0.1` para compatibilidad con `passlib`.
- Se actualizó `seed.sql` con hashes bcrypt válidos de prueba.
- Se actualizó el README del backend con instrucciones de prueba.

## Pruebas realizadas

- Se instaló `passlib[bcrypt]` y `bcrypt==4.0.1`.
- Se importó nuevamente `database/seed.sql`.
- Se levantó backend con Uvicorn.
- Se probó `GET /health`.
- Se probó Swagger en `/docs`.
- Se probó `POST /api/v1/auth/login` con admin válido.
- Se probó `POST /api/v1/auth/login` con vecino válido.
- Se probó contraseña incorrecta con respuesta 401.
- Se probó RUT inválido con respuesta 400.
- Se verificó que no se devuelve `password_hash`.
- Se verificó que no se modificaron `desktop/`, `mobile/`, `emergencies/`, `reports/`, `connection.py` ni `main.py`.

## Credenciales ficticias de prueba

- `admin@vecinoseguro.cl` → `admin1234`
- `carlos.perez@vecinoseguro.cl` → `vecino1234`
- `maria.gonzalez@vecinoseguro.cl` → `vecino1234`

## Issue relacionada

Closes #22 