### PR TITLE
feat: connect desktop status indicator to backend health

### DIFF
--- a/desktop/src/styles/main.qss
+++ b/desktop/src/styles/main.qss
@@ -235,3 +235,22 @@ QScrollBar::handle:vertical {
 }
 QScrollBar::handle:vertical:hover { background: #6B85A8; }
 QScrollBar::add-line:vertical, QScrollBar::sub-line:vertical { height: 0px; }
+
+/* === Chip de estado del backend === */
+QLabel#chipOnline {
+    background-color: #E5F4EA;
+    color: #16812C;
+    padding: 4px 12px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 600;
+}
+
+QLabel#chipOffline {
+    background-color: #FDE8E8;
+    color: #D92D20;
+    padding: 4px 12px;
+    border-radius: 10px;
+    font-size: 11px;
+    font-weight: 600;
+}

--- a/desktop/src/views/main_window.py
+++ b/desktop/src/views/main_window.py
@@ -28,6 +28,7 @@ from src.core.constants import (
     DEFAULT_WINDOW_WIDTH,
 )
 from src.models.entities import Rol, Usuario
+from src.services.api_client import ApiClient
 from src.views.dashboard_view import DashboardView
 from src.views.emergency_form_view import EmergencyFormView
 from src.views.emergency_list_view import EmergencyListView
@@ -198,6 +199,8 @@ class MainWindow(QMainWindow):
         )
         self.list_view.cambio_realizado.connect(self.dashboard.refrescar)
 
+        self._actualizar_estado_backend()
+
         root.addWidget(self.sidebar)
         root.addWidget(self.content_area, 1)
 
@@ -264,3 +267,19 @@ class MainWindow(QMainWindow):
     def _cerrar_sesion(self) -> None:
         self._auth.logout()
         self._on_logout()
+
+    def _actualizar_estado_backend(self) -> None:
+        """Consulta GET /health y actualiza el chip de estado."""
+        try:
+            ApiClient().health_check()
+            self.lbl_chip.setText("● En línea")
+            self.lbl_chip.setStyleSheet(
+                "background-color: #E5F4EA; color: #16812C; "
+                "padding: 4px 12px; border-radius: 10px; font-size: 11px; font-weight: 600;"
+            )
+        except Exception:
+            self.lbl_chip.setText("● Sin conexión")
+            self.lbl_chip.setStyleSheet(
+                "background-color: #FDE8E8; color: #D92D20; "
+                "padding: 4px 12px; border-radius: 10px; font-size: 11px; font-weight: 600;"
+            )


### PR DESCRIPTION
## Resumen

Este PR conecta el indicador superior de estado del desktop con el endpoint de salud del backend.

Ahora la app desktop muestra si el backend está disponible o no usando:

GET /health

## Cambios realizados

- Se conectó el indicador visual "En línea" al estado real del backend.
- Se muestra "En línea" cuando el backend responde correctamente.
- Se muestra "Sin conexión" cuando el backend no responde.
- Se mantuvo la app funcionando aunque el backend esté apagado.
- Se respetó el alcance desktop de la Issue.

## Archivos modificados

- desktop/src/views/main_window.py
- desktop/src/styles/main.qss

## Pruebas realizadas

- [x] Se levantó el backend con Uvicorn.
- [x] Se probó http://127.0.0.1:8000/health en navegador.
- [x] Se ejecutó la app desktop.
- [x] Se verificó que el indicador muestre "En línea" con backend encendido.
- [x] Se verificó que el indicador muestre "Sin conexión" con backend apagado.
- [x] Se verificó que la app no se cae si el backend no responde.

## Restricciones respetadas

- No se modificó backend.
- No se modificó mobile.
- No se modificó database.
- No se modificó el formulario de creación de emergencias.
- No se crearon endpoints nuevos.

## Issue relacionada

Closes #31 