### PR TITLE
feat: show backend system info on desktop

### DIFF
--- a/desktop/src/services/api_client.py
+++ b/desktop/src/services/api_client.py
@@ -32,6 +32,17 @@ class ApiClient:
         response.raise_for_status()
         return response.json()
 
+    def get_system_info(self) -> dict | None:
+        """Obtiene información general del backend."""
+        try:
+            response = requests.get(
+                f"{self.base_url}/api/v1/system/info", timeout=10
+            )
+            response.raise_for_status()
+            return response.json()
+        except Exception:
+            return None
+
     def get_emergencies(self) -> list[dict] | None:
         """Obtiene la lista de emergencias del backend."""
         try:

--- a/desktop/src/views/main_window.py
+++ b/desktop/src/views/main_window.py
@@ -277,6 +277,19 @@ class MainWindow(QMainWindow):
         """Consulta GET /health y actualiza el chip de estado."""
         try:
             ApiClient().health_check()
-            self._set_backend_chip_state(True)
+            online = True
         except Exception:
-            self._set_backend_chip_state(False)
+            online = False
+
+        self._set_backend_chip_state(online)
+
+        info = ApiClient().get_system_info()
+        if info:
+            self.lbl_chip.setToolTip(
+                f"Backend: {info.get('app_name', 'VecinoSeguro')}\n"
+                f"Versión: {info.get('version', 'N/D')}\n"
+                f"Ambiente: {info.get('environment', 'N/D')}\n"
+                f"Estado: {info.get('status', 'N/D')}"
+            )
+        else:
+            self.lbl_chip.setToolTip("Información del sistema no disponible")


### PR DESCRIPTION
## Resumen

Este PR muestra información general del backend en la interfaz desktop usando el endpoint existente:

`GET /api/v1/system/info`

## Cambios realizados

- Se agregó `get_system_info()` en `ApiClient` siguiendo el mismo patrón de `health_check()`.
- Se actualizó `_actualizar_estado_backend()` en `MainWindow` para consultar la info del sistema y mostrarla como tooltip del chip de estado.
- Se maneja el caso en que el backend no esté disponible sin lanzar traceback.

## Archivos modificados

- `desktop/src/services/api_client.py`
- `desktop/src/views/main_window.py`

## Pruebas realizadas

- [ ] Se levantó el backend con Uvicorn.
- [ ] Se probó `/api/v1/system/info` en navegador o Swagger.
- [ ] Se ejecutó la app desktop.
- [ ] Se probó el login actual.
- [ ] Se verificó que el tooltip del chip muestra la info del backend encendido.
- [ ] Se verificó que la app no se cae con backend apagado.

## Restricciones respetadas

- No se modificó backend.
- No se modificó mobile.
- No se modificó database.
- No se modificó el formulario de creación de emergencias.
- No se modificó el dashboard de reportes.
- No se crearon endpoints nuevos.

## Issue relacionada

Closes #36