### PR TITLE
Crear endpoint de tarjetas para dashboard desde reportes

### DIFF
--- a/backend/app/modules/reports/router.py
+++ b/backend/app/modules/reports/router.py
@@ -2,7 +2,10 @@
 
 from fastapi import APIRouter
 
-from app.modules.reports.schemas import ReportsSummaryResponse
+from app.modules.reports.schemas import (
+    DashboardCardsResponse,
+    ReportsSummaryResponse,
+)
 from app.modules.reports.service import ReportService
 
 router = APIRouter()
@@ -13,3 +16,9 @@ report_service = ReportService()
 def get_summary() -> ReportsSummaryResponse:
     """Entrega estadísticas agregadas de emergencias."""
     return report_service.get_summary()
+
+
+@router.get("/dashboard-cards", response_model=DashboardCardsResponse)
+def get_dashboard_cards() -> DashboardCardsResponse:
+    """Entrega tarjetas de indicadores para dashboard."""
+    return report_service.get_dashboard_cards()

--- a/backend/app/modules/reports/schemas.py
+++ b/backend/app/modules/reports/schemas.py
@@ -17,3 +17,17 @@ class ReportsSummaryResponse(BaseModel):
     total_emergencies: int
     by_status: dict[str, int]
     by_urgency: dict[str, int]
+
+
+class DashboardCard(BaseModel):
+    """Tarjeta simple para mostrar indicadores en dashboard."""
+
+    key: str
+    label: str
+    value: int
+
+
+class DashboardCardsResponse(BaseModel):
+    """Respuesta con tarjetas de indicadores para dashboard."""
+
+    cards: list[DashboardCard]

--- a/backend/app/modules/reports/service.py
+++ b/backend/app/modules/reports/service.py
@@ -1,7 +1,11 @@
 """Servicio de reportes y estadísticas agregadas."""
 
 from app.modules.reports.repository import ReportRepository
-from app.modules.reports.schemas import ReportsSummaryResponse
+from app.modules.reports.schemas import (
+    DashboardCard,
+    DashboardCardsResponse,
+    ReportsSummaryResponse,
+)
 
 
 class ReportService:
@@ -35,4 +39,39 @@ class ReportService:
             total_emergencies=total_emergencies,
             by_status=normalized_status,
             by_urgency=normalized_urgency,
+        )
+
+    def get_dashboard_cards(self) -> DashboardCardsResponse:
+        """Retorna indicadores preparados como tarjetas para dashboard."""
+
+        summary = self.get_summary()
+
+        return DashboardCardsResponse(
+            cards=[
+                DashboardCard(
+                    key="total",
+                    label="Emergencias totales",
+                    value=summary.total_emergencies,
+                ),
+                DashboardCard(
+                    key="pendiente",
+                    label="Pendientes",
+                    value=summary.by_status.get("pendiente", 0),
+                ),
+                DashboardCard(
+                    key="en_revision",
+                    label="En revisión",
+                    value=summary.by_status.get("en_revision", 0),
+                ),
+                DashboardCard(
+                    key="resuelto",
+                    label="Resueltas",
+                    value=summary.by_status.get("resuelto", 0),
+                ),
+                DashboardCard(
+                    key="critica",
+                    label="Urgencia crítica",
+                    value=summary.by_urgency.get("critica", 0),
+                ),
+            ]
         )


### PR DESCRIPTION
## Descripción
 
Se agrega un endpoint de tarjetas para dashboard dentro del módulo de reportes del backend.
 
Endpoint implementado:
 
```http
GET /api/v1/reports/dashboard-cards
```
 
## Cambios realizados
 
- Se agregaron schemas Pydantic para tarjetas de dashboard.
- Se agregó lógica en `ReportService` para construir tarjetas a partir del resumen existente.
- Se agregó una ruta nueva en el router de reportes.
 
## Pruebas realizadas
 
- Se levantó el backend con Uvicorn.
- Se revisó Swagger en `http://127.0.0.1:8000/docs`.
- Se probó `GET /api/v1/reports/dashboard-cards`.
- Se verificó que `GET /api/v1/reports/summary` sigue funcionando.
- Se verificó que `GET /api/v1/emergencies/` sigue funcionando.
 
## Alcance
 
No se modificó:
 
- `desktop/`
- `mobile/`
- `database/`
- `backend/app/modules/emergencies/`
- `backend/app/modules/auth/`
- `backend/app/modules/users/`
- `backend/app/db/connection.py`
- `backend/app/main/main.py`
 
Closes #30 
