### PR TITLE
fix: avoid duplicate dashboard refresh on login

### DIFF
--- a/desktop/src/views/main_window.py
+++ b/desktop/src/views/main_window.py
@@ -241,8 +241,6 @@ class MainWindow(QMainWindow):
         self.form_view.set_usuario(usuario)
         self.list_view.set_usuario(usuario)
 
-        self.dashboard.refrescar()
-        self.list_view.refrescar()
         self.ir_a(self.PAG_DASH)
 
     def ir_a(self, indice: int) -> None:


### PR DESCRIPTION
## Resumen

Este PR optimiza la carga inicial del dashboard desktop después del login, evitando refrescos duplicados e innecesarios al ingresar a la aplicación.

## Cambios realizados

- Se eliminaron llamadas redundantes a `dashboard.refrescar()` dentro de `MainWindow.set_usuario(...)`.
- Se eliminó la carga inicial innecesaria de `list_view.refrescar()` al iniciar sesión.
- Se mantiene `self.ir_a(self.PAG_DASH)` como responsable de mostrar el dashboard y ejecutar un único refresco inicial.
- El listado de reportes sigue cargándose normalmente cuando el usuario entra a la sección “Reportes”.
- La navegación hacia “Inicio” sigue refrescando el dashboard.

## Pruebas realizadas

- [x] Ejecutado `.\.venv\Scripts\python.exe -m compileall src` sin errores.
- [x] App desktop abierta correctamente.
- [x] Login probado con credenciales reales.
- [x] Verificado que el dashboard se muestra correctamente después del login.
- [x] Verificado que el ingreso se siente más rápido.
- [x] Verificado que “Reportes” carga correctamente al ingresar a esa sección.
- [x] Verificado que volver a “Inicio” refresca correctamente el dashboard.
- [x] Ejecutado `git diff --check` sin errores.

## Archivos modificados

- `desktop/src/views/main_window.py`

## No se modificó

- `backend/`
- `mobile/`
- `database/`
- autenticación
- controladores
- servicios
- modelos
- `dashboard_view.py`
- `emergency_list_view.py`
- `README.md`