### PR TITLE
fix: remove duplicate emergency find by id method

### DIFF
--- a/backend/app/modules/emergencies/repository.py
+++ b/backend/app/modules/emergencies/repository.py
@@ -12,35 +12,6 @@ from app.modules.emergencies.schemas import EmergencyCreate, EmergencySummary
 class EmergencyRepository:
     """Consulta emergencias almacenadas en MySQL."""
 
-    def find_by_id(self, emergency_id: int) -> EmergencySummary | None:
-        """Busca una emergencia por id y retorna ``None`` si no existe."""
-        query = """
-            SELECT
-                id,
-                user_id,
-                type,
-                description,
-                location,
-                urgency_level,
-                status,
-                created_at,
-                updated_at
-            FROM emergencies
-            WHERE id = %s
-        """
-
-        connection = get_connection()
-        cursor = None
-        try:
-            cursor = connection.cursor(dictionary=True)
-            cursor.execute(query, (emergency_id,))
-            row = cursor.fetchone()
-            return EmergencySummary(**row) if row is not None else None
-        finally:
-            if cursor is not None:
-                cursor.close()
-            connection.close()
-
     def list_emergencies(self) -> list[EmergencySummary]:
         """Retorna todas las emergencias ordenadas por fecha descendente.
 


### PR DESCRIPTION
## Descripción

Se realiza un fix menor posterior al PR #51 para limpiar el código del repositorio de emergencias.

## Cambios realizados

- Se eliminó un método `find_by_id` duplicado en `EmergencyRepository`.
- Se conservó la versión correcta del método, que usa `LIMIT 1`.
- No se cambió la funcionalidad del endpoint `GET /api/v1/emergencies/{emergency_id}`.
- No se modificaron otros archivos.

## Pruebas realizadas

- `GET /health`
- `GET /api/v1/emergencies/`
- `GET /api/v1/emergencies/catalogs`
- `GET /api/v1/emergencies/1`
- `GET /api/v1/emergencies/9999`

## Contexto

Este ajuste limpia deuda técnica detectada después del merge del PR #51, donde quedó duplicado el método `find_by_id` en `backend/app/modules/emergencies/repository.py`.