### PR TITLE
feat: connect mobile emergency list to backend

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -2,7 +2,7 @@
 
 Avance inicial de la app movil de VecinoSeguro, preparada con Expo SDK 54, React Native y TypeScript para uso con la version actual de Expo Go.
 
-VecinoSeguro permite reportar, visualizar y organizar emergencias locales de forma rapida, clara y colaborativa. Esta version conecta el login movil con el backend FastAPI real y mantiene el listado/formulario de emergencias con datos simulados.
+VecinoSeguro permite reportar, visualizar y organizar emergencias locales de forma rapida, clara y colaborativa. Esta version conecta el login movil y el listado de emergencias con el backend FastAPI real, manteniendo la creacion movil de emergencias como flujo simulado.
 
 ## Requisitos
 
@@ -39,12 +39,18 @@ La app lee la URL base del backend desde variables publicas de Expo. No se debe 
 EXPO_PUBLIC_API_URL=http://localhost:8000
 ```
 
-El login movil consume `POST /api/v1/auth/login`, por lo que requiere que FastAPI este levantado y accesible desde el dispositivo donde corre Expo.
+El login movil consume `POST /api/v1/auth/login` y el Home/listado de emergencias consumen `GET /api/v1/emergencies/`, por lo que requiere que FastAPI este levantado y accesible desde el dispositivo donde corre Expo.
 
 Para web o ciertos emuladores, `localhost` puede funcionar. En un telefono fisico con Expo Go, `localhost` apunta al telefono y no al PC; usa la IP local del computador conectado a la misma red WiFi:
 
 ```text
 EXPO_PUBLIC_API_URL=http://192.168.1.11:8000
+```
+
+Si pruebas desde un telefono fisico, levanta el backend escuchando en todas las interfaces para que Expo Go pueda alcanzarlo desde la red local:
+
+```bash
+uvicorn app.main.main:app --host 0.0.0.0 --port 8000 --reload
 ```
 
 Credenciales de desarrollo disponibles con la base cargada desde `database/seed.sql`:
@@ -64,9 +70,9 @@ Contrasena: vecino1234
 - Login movil real con RUT y contrasena contra `POST /api/v1/auth/login`.
 - Validacion basica local de formato de RUT antes de autenticar.
 - Estado de usuario autenticado en memoria mientras la app esta abierta.
-- Home/dashboard con resumen de emergencias.
-- Formulario visual para registrar emergencia.
-- Listado inicial de emergencias con datos mock.
+- Home/dashboard con resumen de emergencias reales desde `GET /api/v1/emergencies/`.
+- Listado de emergencias reales desde `GET /api/v1/emergencies/`.
+- Formulario visual para registrar emergencia, aun simulado en mobile.
 - Componentes reutilizables para boton, tarjeta, badge de estado y layout base.
 - Paleta visual alineada a la identidad de VecinoSeguro.
 - Cliente API preparado para consumir endpoints de FastAPI.
@@ -74,8 +80,8 @@ Contrasena: vecino1234
 ## Funcionalidades simuladas
 
 - El registro de emergencias muestra confirmacion visual, pero no persiste en backend.
-- Los reportes se cargan desde `src/data/mockEmergencies.ts`.
-- El listado y el formulario movil de emergencias siguen usando datos simulados por ahora.
+- Las emergencias creadas desde el formulario simulado no aparecen todavia en el listado real.
+- La creacion real de emergencias desde mobile se implementara en una etapa posterior.
 
 ## Fuera de alcance en esta etapa
 
@@ -84,14 +90,14 @@ Contrasena: vecino1234
 - Notificaciones push.
 - Persistencia real desde mobile.
 - Persistencia de sesion con AsyncStorage.
-- Listado y creacion de emergencias reales desde mobile.
+- Creacion de emergencias reales desde mobile.
 - Chat, roles avanzados o integraciones institucionales.
 
 ## Estructura relevante
 
 - `app/`: punto de entrada para Expo Router.
 - `src/components/`: componentes reutilizables.
-- `src/data/`: datos simulados para el avance inicial.
+- `src/data/`: datos simulados usados por flujos aun no conectados al backend.
 - `src/screens/`: pantallas principales.
 - `src/services/`: comunicación con FastAPI.
 - `src/styles/`: tokens visuales de la app.

--- a/mobile/src/screens/EmergencyListScreen.tsx
+++ b/mobile/src/screens/EmergencyListScreen.tsx
@@ -15,24 +15,57 @@ interface EmergencyListScreenProps {
 
 export function EmergencyListScreen({ onBack, onRegisterEmergency }: EmergencyListScreenProps) {
   const [emergencies, setEmergencies] = useState<Emergency[]>([]);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
 
   useEffect(() => {
     let isMounted = true;
 
-    getEmergencies().then((items) => {
-      if (isMounted) {
-        setEmergencies(items);
+    async function loadEmergencies() {
+      try {
+        const items = await getEmergencies();
+
+        if (isMounted) {
+          setEmergencies(items);
+          setErrorMessage("");
+        }
+      } catch {
+        if (isMounted) {
+          setErrorMessage("No fue posible cargar las emergencias. Verifica que el backend esté disponible.");
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
       }
-    });
+    }
+
+    loadEmergencies();
 
     return () => {
       isMounted = false;
     };
   }, []);
 
+  const renderEmergencies = () => {
+    if (isLoading) {
+      return <Text style={styles.feedbackText}>Cargando emergencias...</Text>;
+    }
+
+    if (errorMessage) {
+      return <Text style={styles.errorText}>{errorMessage}</Text>;
+    }
+
+    if (emergencies.length === 0) {
+      return <Text style={styles.feedbackText}>No hay emergencias registradas.</Text>;
+    }
+
+    return emergencies.map((emergency) => <EmergencyCard emergency={emergency} key={emergency.id} />);
+  };
+
   return (
     <AppLayout
-      subtitle="Listado inicial con datos simulados para presentar estados, urgencias y ubicaciones."
+      subtitle="Reportes registrados por la comunidad con sus estados, urgencias y ubicaciones."
       title="Emergencias"
     >
       <View style={styles.actions}>
@@ -42,14 +75,10 @@ export function EmergencyListScreen({ onBack, onRegisterEmergency }: EmergencyLi
 
       <View style={styles.sectionHeader}>
         <Text style={styles.sectionTitle}>Reportes comunitarios</Text>
-        <Text style={styles.sectionSubtitle}>{emergencies.length} reportes simulados disponibles.</Text>
+        <Text style={styles.sectionSubtitle}>{emergencies.length} reportes disponibles.</Text>
       </View>
 
-      <View style={styles.list}>
-        {emergencies.map((emergency) => (
-          <EmergencyCard emergency={emergency} key={emergency.id} />
-        ))}
-      </View>
+      <View style={styles.list}>{renderEmergencies()}</View>
     </AppLayout>
   );
 }
@@ -61,6 +90,18 @@ const styles = StyleSheet.create({
   },
   list: {
     gap: spacing.md,
+  },
+  errorText: {
+    color: colors.danger,
+    fontSize: 14,
+    fontWeight: "600",
+    lineHeight: 20,
+  },
+  feedbackText: {
+    color: colors.textSecondary,
+    fontSize: 14,
+    fontWeight: "600",
+    lineHeight: 20,
   },
   sectionHeader: {
     marginBottom: spacing.md,

--- a/mobile/src/screens/HomeScreen.tsx
+++ b/mobile/src/screens/HomeScreen.tsx
@@ -7,7 +7,7 @@ import { PrimaryButton } from "../components/PrimaryButton";
 import { getEmergencies } from "../services/emergencyService";
 import { colors, radii, shadows, spacing } from "../styles/theme";
 import type { AuthenticatedUser } from "../types/auth";
-import type { Emergency, EmergencyStatus } from "../types/emergency";
+import type { Emergency } from "../types/emergency";
 
 interface HomeScreenProps {
   onLogout: () => void;
@@ -16,32 +16,92 @@ interface HomeScreenProps {
   user: AuthenticatedUser | null;
 }
 
-const summaryConfig: Array<{ label: string; status: EmergencyStatus; color: string }> = [
-  { color: colors.warning, label: "Pendientes", status: "pending" },
-  { color: colors.info, label: "En revisión", status: "in_review" },
-  { color: colors.success, label: "Resueltas", status: "resolved" },
-  { color: colors.danger, label: "Críticas", status: "critical" },
+interface SummaryItem {
+  color: string;
+  key: string;
+  label: string;
+  matches: (emergency: Emergency) => boolean;
+}
+
+const summaryConfig: SummaryItem[] = [
+  {
+    color: colors.warning,
+    key: "pending",
+    label: "Pendientes",
+    matches: (emergency) => emergency.status === "pending",
+  },
+  {
+    color: colors.info,
+    key: "in_review",
+    label: "En revisión",
+    matches: (emergency) => emergency.status === "in_review",
+  },
+  {
+    color: colors.success,
+    key: "resolved",
+    label: "Resueltas",
+    matches: (emergency) => emergency.status === "resolved",
+  },
+  {
+    color: colors.danger,
+    key: "critical",
+    label: "Críticas",
+    matches: (emergency) => emergency.urgencyLevel === "critical",
+  },
 ];
 
 const getRoleLabel = (roleId?: number) => (roleId === 1 ? "Administrador" : "Vecino");
 
 export function HomeScreen({ onLogout, onRegisterEmergency, onViewEmergencies, user }: HomeScreenProps) {
   const [emergencies, setEmergencies] = useState<Emergency[]>([]);
+  const [errorMessage, setErrorMessage] = useState("");
+  const [isLoading, setIsLoading] = useState(true);
   const latestEmergencies = emergencies.slice(0, 3);
 
   useEffect(() => {
     let isMounted = true;
 
-    getEmergencies().then((items) => {
-      if (isMounted) {
-        setEmergencies(items);
+    async function loadEmergencies() {
+      try {
+        const items = await getEmergencies();
+
+        if (isMounted) {
+          setEmergencies(items);
+          setErrorMessage("");
+        }
+      } catch {
+        if (isMounted) {
+          setErrorMessage("No fue posible cargar las emergencias. Verifica que el backend esté disponible.");
+        }
+      } finally {
+        if (isMounted) {
+          setIsLoading(false);
+        }
       }
-    });
+    }
+
+    loadEmergencies();
 
     return () => {
       isMounted = false;
     };
   }, []);
+
+  const renderLatestEmergencies = () => {
+    if (isLoading) {
+      return <Text style={styles.feedbackText}>Cargando emergencias...</Text>;
+    }
+
+    if (errorMessage) {
+      return <Text style={styles.errorText}>{errorMessage}</Text>;
+    }
+
+    if (latestEmergencies.length === 0) {
+      return <Text style={styles.feedbackText}>No hay emergencias registradas.</Text>;
+    }
+
+    return latestEmergencies.map((emergency) => <EmergencyCard emergency={emergency} key={emergency.id} />);
+  };
 
   return (
     <AppLayout
@@ -60,10 +120,10 @@ export function HomeScreen({ onLogout, onRegisterEmergency, onViewEmergencies, u
 
       <View style={styles.summaryGrid}>
         {summaryConfig.map((item) => {
-          const count = emergencies.filter((emergency) => emergency.status === item.status).length;
+          const count = emergencies.filter(item.matches).length;
 
           return (
-            <View key={item.status} style={styles.summaryCard}>
+            <View key={item.key} style={styles.summaryCard}>
               <View style={[styles.summaryIndicator, { backgroundColor: item.color }]} />
               <Text style={styles.summaryCount}>{count}</Text>
               <Text style={styles.summaryLabel}>{item.label}</Text>
@@ -75,15 +135,11 @@ export function HomeScreen({ onLogout, onRegisterEmergency, onViewEmergencies, u
       <View style={styles.sectionHeader}>
         <View>
           <Text style={styles.sectionTitle}>Últimos reportes</Text>
-          <Text style={styles.sectionSubtitle}>Emergencias simuladas para validar el flujo inicial.</Text>
+          <Text style={styles.sectionSubtitle}>Últimos reportes registrados en la comunidad.</Text>
         </View>
       </View>
 
-      <View style={styles.list}>
-        {latestEmergencies.map((emergency) => (
-          <EmergencyCard emergency={emergency} key={emergency.id} />
-        ))}
-      </View>
+      <View style={styles.list}>{renderLatestEmergencies()}</View>
 
       <PrimaryButton label="Ver listado completo" onPress={onViewEmergencies} variant="secondary" />
     </AppLayout>
@@ -98,6 +154,18 @@ const styles = StyleSheet.create({
   list: {
     gap: spacing.md,
     marginBottom: spacing.lg,
+  },
+  errorText: {
+    color: colors.danger,
+    fontSize: 14,
+    fontWeight: "600",
+    lineHeight: 20,
+  },
+  feedbackText: {
+    color: colors.textSecondary,
+    fontSize: 14,
+    fontWeight: "600",
+    lineHeight: 20,
   },
   sectionHeader: {
     marginBottom: spacing.md,

--- a/mobile/src/services/apiClient.ts
+++ b/mobile/src/services/apiClient.ts
@@ -1,5 +1,6 @@
 import { environment } from "../config/environment";
 import type { AuthenticatedUser, LoginResponse } from "../types/auth";
+import type { BackendEmergency } from "../types/emergency";
 
 const trimTrailingSlash = (value: string) => value.replace(/\/+$/, "");
 
@@ -38,6 +39,8 @@ interface BackendLoginResponse {
 
 const loginNetworkErrorMessage =
   "No fue posible conectar con el backend. Verifica que FastAPI esté en ejecución y que la URL de API sea correcta.";
+const emergenciesNetworkErrorMessage =
+  "No fue posible cargar las emergencias. Verifica que el backend esté disponible y que la URL de API sea correcta.";
 
 function normalizeRutForLogin(rut: string) {
   return rut.trim().replace(/\./g, "").toUpperCase();
@@ -89,6 +92,26 @@ function isBackendLoginResponse(data: unknown): data is BackendLoginResponse {
   );
 }
 
+function isBackendEmergency(data: unknown): data is BackendEmergency {
+  if (!data || typeof data !== "object") {
+    return false;
+  }
+
+  const emergency = data as Partial<BackendEmergency>;
+
+  return (
+    typeof emergency.id === "number" &&
+    typeof emergency.user_id === "number" &&
+    typeof emergency.type === "string" &&
+    typeof emergency.description === "string" &&
+    typeof emergency.location === "string" &&
+    typeof emergency.urgency_level === "string" &&
+    typeof emergency.status === "string" &&
+    typeof emergency.created_at === "string" &&
+    (typeof emergency.updated_at === "string" || emergency.updated_at === null)
+  );
+}
+
 export async function login(rut: string, password: string): Promise<LoginResponse> {
   let response: Response;
 
@@ -128,4 +151,32 @@ export async function login(rut: string, password: string): Promise<LoginRespons
     success: data.success,
     user: mapAuthenticatedUser(data.user),
   };
+}
+
+export async function getBackendEmergencies(): Promise<BackendEmergency[]> {
+  let response: Response;
+
+  try {
+    response = await fetch(buildApiUrl("/api/v1/emergencies/"));
+  } catch {
+    throw new Error(emergenciesNetworkErrorMessage);
+  }
+
+  if (!response.ok) {
+    throw new Error("No fue posible cargar las emergencias desde el backend.");
+  }
+
+  let data: unknown;
+
+  try {
+    data = await response.json();
+  } catch {
+    throw new Error("El backend devolvió una respuesta de emergencias inválida.");
+  }
+
+  if (!Array.isArray(data) || !data.every(isBackendEmergency)) {
+    throw new Error("El backend devolvió una respuesta de emergencias inválida.");
+  }
+
+  return data;
 }

--- a/mobile/src/services/emergencyService.ts
+++ b/mobile/src/services/emergencyService.ts
@@ -1,17 +1,79 @@
 import { mockEmergencies } from "../data/mockEmergencies";
-import type { CreateEmergencyInput, Emergency } from "../types/emergency";
+import { getBackendEmergencies } from "./apiClient";
+import type {
+  BackendEmergency,
+  CreateEmergencyInput,
+  Emergency,
+  EmergencyStatus,
+  UrgencyLevel,
+} from "../types/emergency";
 
 let emergencyStore: Emergency[] = [...mockEmergencies];
 
 const cloneEmergency = (emergency: Emergency): Emergency => ({ ...emergency });
 
-// Fuente temporal basada en mocks; preparada para reemplazarse por llamadas HTTP.
+const statusMap: Record<string, EmergencyStatus> = {
+  en_revision: "in_review",
+  pendiente: "pending",
+  resuelto: "resolved",
+};
+
+const urgencyMap: Record<string, UrgencyLevel> = {
+  alta: "high",
+  baja: "low",
+  critica: "critical",
+  crítica: "critical",
+  media: "medium",
+};
+
+const typeLabels: Record<string, string> = {
+  accidente: "Accidente",
+  corte_luz: "Corte de luz",
+  emergencia_medica: "Emergencia médica",
+  incendio: "Incendio",
+  otro: "Otro",
+  persona_extraviada: "Persona extraviada",
+  robo: "Robo",
+  solicitud_ayuda: "Solicitud de ayuda",
+};
+
+function normalizeBackendValue(value: string) {
+  return value.trim().toLowerCase();
+}
+
+function toReadableType(value: string) {
+  const normalizedValue = normalizeBackendValue(value);
+  const mappedLabel = typeLabels[normalizedValue];
+
+  if (mappedLabel) {
+    return mappedLabel;
+  }
+
+  const readableValue = normalizedValue.replace(/_/g, " ");
+
+  return readableValue.charAt(0).toUpperCase() + readableValue.slice(1);
+}
+
+function mapBackendEmergency(emergency: BackendEmergency): Emergency {
+  return {
+    createdAt: emergency.created_at,
+    description: emergency.description,
+    id: String(emergency.id),
+    location: emergency.location,
+    status: statusMap[normalizeBackendValue(emergency.status)] ?? "pending",
+    type: toReadableType(emergency.type),
+    urgencyLevel: urgencyMap[normalizeBackendValue(emergency.urgency_level)] ?? "medium",
+  };
+}
+
 export async function getEmergencies(): Promise<Emergency[]> {
-  return emergencyStore.map(cloneEmergency);
+  const backendEmergencies = await getBackendEmergencies();
+
+  return backendEmergencies.map(mapBackendEmergency);
 }
 
 export async function getEmergencyById(id: string): Promise<Emergency | null> {
-  const emergency = emergencyStore.find((item) => item.id === id);
+  const emergency = (await getEmergencies()).find((item) => item.id === id);
 
   return emergency ? cloneEmergency(emergency) : null;
 }

--- a/mobile/src/types/emergency.ts
+++ b/mobile/src/types/emergency.ts
@@ -2,6 +2,18 @@ export type EmergencyStatus = "pending" | "in_review" | "resolved" | "critical";
 
 export type UrgencyLevel = "low" | "medium" | "high" | "critical";
 
+export interface BackendEmergency {
+  id: number;
+  user_id: number;
+  type: string;
+  description: string;
+  location: string;
+  urgency_level: string;
+  status: string;
+  created_at: string;
+  updated_at: string | null;
+}
+
 // Tipo compartido para representar emergencias dentro de la app movil.
 export interface Emergency {
   id: string;


### PR DESCRIPTION
## Resumen

Este PR conecta el Home y el listado de emergencias de la app móvil con el backend real de VecinoSeguro.

Hasta ahora, la app móvil mostraba emergencias simuladas. Con este cambio, `HomeScreen` y `EmergencyListScreen` consumen `GET /api/v1/emergencies/` desde FastAPI y muestran reportes reales registrados en MySQL/MariaDB.

## Cambios realizados

- Se agregó consumo real de `GET /api/v1/emergencies/` desde `mobile/src/services/apiClient.ts`.
- Se actualizó `mobile/src/services/emergencyService.ts` para mapear emergencias del backend al modelo usado por la app móvil.
- Se agregaron tipos para la respuesta del backend en `mobile/src/types/emergency.ts`.
- `HomeScreen` ahora carga emergencias reales para KPIs y últimos reportes.
- `EmergencyListScreen` ahora muestra reportes reales del backend.
- Se agregaron estados de carga, error y listado vacío.
- Se ajustó el KPI “Críticas” para contar emergencias con `urgencyLevel === "critical"`.
- Se eliminaron textos que indicaban reportes simulados en Home/Listado.
- Se actualizó `mobile/README.md` con el nuevo alcance.
- El formulario móvil de creación de emergencias se mantiene simulado.

## Pruebas realizadas

- [x] Ejecutado `npx tsc --noEmit` sin errores.
- [x] Ejecutado `git diff --check` sin errores.
- [x] Backend levantado desde `backend/` con:
  `uvicorn app.main.main:app --host 0.0.0.0 --port 8000 --reload`
- [x] App móvil abierta con Expo Go.
- [x] Login exitoso con usuario real.
- [x] Verificado que Home muestra KPIs con datos reales.
- [x] Verificado que “Últimos reportes” muestra emergencias reales.
- [x] Verificado que “Ver listado completo” muestra reportes reales.
- [x] Verificado que ya no aparecen textos de reportes simulados en Home/Listado.
- [x] Verificado que el formulario de emergencia sigue funcionando como flujo simulado.
- [x] Verificado que si el backend no está disponible, la app muestra error y no crashea.

## Alcance

Este PR conecta únicamente la lectura/listado de emergencias reales en mobile.

## No se modificó

- `backend/`
- `desktop/`
- `database/`
- creación real de emergencias desde mobile
- persistencia de sesión con AsyncStorage
- endpoints `summary` o `recent`
- geolocalización
- mapas
- notificaciones

## Issue relacionada

Closes #50 