### PR TITLE
feat: optimize dashboard data loading with summary and recent endpoints

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -150,6 +150,8 @@ GET /api/v1/system/info
 POST /api/v1/auth/login
 POST /api/v1/users/
 GET /api/v1/emergencies/
+GET /api/v1/emergencies/summary
+GET /api/v1/emergencies/recent?limit=4
 GET /api/v1/emergencies/catalogs
 GET /api/v1/emergencies/{emergency_id}
 POST /api/v1/emergencies/
@@ -325,6 +327,62 @@ Ejemplo:
     "status": "pendiente",
     "created_at": "2026-05-04T00:00:00",
     "updated_at": "2026-05-04T00:00:00"
+  }
+]
+```
+
+---
+
+## Resumen optimizado para dashboard
+
+```text
+GET /api/v1/emergencies/summary
+```
+
+Devuelve contadores por estado sin transferir todo el listado de emergencias.
+Este endpoint optimiza la carga de KPIs del dashboard desktop.
+
+Ejemplo:
+
+```json
+{
+  "pendiente": 2,
+  "en_revision": 1,
+  "atendido": 0,
+  "resuelto": 3
+}
+```
+
+Nota: `atendido` se devuelve en `0` por compatibilidad con el dashboard
+desktop; el backend actual no lo maneja como estado válido.
+
+---
+
+## Emergencias recientes para dashboard
+
+```text
+GET /api/v1/emergencies/recent?limit=4
+```
+
+Devuelve las emergencias más recientes, ordenadas por fecha de creación
+descendente, sin consultar todo el historial. Este endpoint optimiza la sección
+de reportes recientes del dashboard desktop. El parámetro `limit` se acota entre
+`1` y `20`.
+
+Ejemplo:
+
+```json
+[
+  {
+    "id": 4,
+    "user_id": 2,
+    "type": "incendio",
+    "description": "Humo visible en una vivienda cercana",
+    "location": "Pasaje Los Aromos 123",
+    "urgency_level": "alta",
+    "status": "pendiente",
+    "created_at": "2026-05-04T14:00:00",
+    "updated_at": null
   }
 ]
 ```
@@ -510,10 +568,12 @@ Ejemplo de respuesta:
 6. Probar errores de RUT inválido, RUT duplicado, email duplicado y contraseña corta.
 7. Confirmar que la respuesta de usuarios no incluya `password_hash`.
 8. Probar `GET /api/v1/emergencies/`.
-9. Probar `GET /api/v1/emergencies/catalogs`.
-10. Probar `GET /api/v1/reports/summary`.
-11. Probar `GET /api/v1/reports/dashboard-cards`.
-12. Verificar que las respuestas sean coherentes con los datos cargados desde `database/seed.sql`.
+9. Probar `GET /api/v1/emergencies/summary`.
+10. Probar `GET /api/v1/emergencies/recent?limit=4`.
+11. Probar `GET /api/v1/emergencies/catalogs`.
+12. Probar `GET /api/v1/reports/summary`.
+13. Probar `GET /api/v1/reports/dashboard-cards`.
+14. Verificar que las respuestas sean coherentes con los datos cargados desde `database/seed.sql`.
 
 ---
 

--- a/backend/app/modules/emergencies/repository.py
+++ b/backend/app/modules/emergencies/repository.py
@@ -6,7 +6,11 @@ cuenta: deben hacerlo siempre a través de este repositorio.
 """
 
 from app.db.connection import get_connection
-from app.modules.emergencies.schemas import EmergencyCreate, EmergencySummary
+from app.modules.emergencies.schemas import (
+    EmergencyCreate,
+    EmergencySummary,
+    EmergencySummaryStats,
+)
 
 
 class EmergencyRepository:
@@ -39,6 +43,66 @@ class EmergencyRepository:
         try:
             cursor = connection.cursor(dictionary=True)
             cursor.execute(query)
+            rows = cursor.fetchall()
+            return [EmergencySummary(**row) for row in rows]
+        finally:
+            if cursor is not None:
+                cursor.close()
+            connection.close()
+
+    def get_summary(self) -> EmergencySummaryStats:
+        """Cuenta emergencias por estado para el dashboard."""
+        query = """
+            SELECT status, COUNT(*) AS total
+            FROM emergencies
+            GROUP BY status
+        """
+        counts = {
+            "pendiente": 0,
+            "en_revision": 0,
+            "atendido": 0,
+            "resuelto": 0,
+        }
+
+        connection = get_connection()
+        cursor = None
+        try:
+            cursor = connection.cursor(dictionary=True)
+            cursor.execute(query)
+            rows = cursor.fetchall()
+            for row in rows:
+                status = row.get("status")
+                if status in counts:
+                    counts[status] = int(row.get("total") or 0)
+            return EmergencySummaryStats(**counts)
+        finally:
+            if cursor is not None:
+                cursor.close()
+            connection.close()
+
+    def list_recent(self, limit: int = 4) -> list[EmergencySummary]:
+        """Retorna las emergencias recientes ordenadas por fecha descendente."""
+        query = """
+            SELECT
+                id,
+                user_id,
+                type,
+                description,
+                location,
+                urgency_level,
+                status,
+                created_at,
+                updated_at
+            FROM emergencies
+            ORDER BY created_at DESC
+            LIMIT %s
+        """
+
+        connection = get_connection()
+        cursor = None
+        try:
+            cursor = connection.cursor(dictionary=True)
+            cursor.execute(query, (limit,))
             rows = cursor.fetchall()
             return [EmergencySummary(**row) for row in rows]
         finally:

--- a/backend/app/modules/emergencies/router.py
+++ b/backend/app/modules/emergencies/router.py
@@ -11,6 +11,7 @@ from app.modules.emergencies.schemas import (
     EmergencyCreate,
     EmergencyStatusUpdate,
     EmergencySummary,
+    EmergencySummaryStats,
 )
 from app.modules.emergencies.service import (
     EmergencyNotFoundError,
@@ -37,6 +38,30 @@ def list_emergencies() -> list[EmergencySummary]:
         raise HTTPException(
             status_code=500,
             detail="No fue posible obtener las emergencias",
+        ) from exc
+
+
+@router.get("/summary", response_model=EmergencySummaryStats)
+def get_emergencies_summary() -> EmergencySummaryStats:
+    """Entrega contadores por estado para el dashboard."""
+    try:
+        return emergency_service.get_summary()
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="No fue posible obtener el resumen de emergencias",
+        ) from exc
+
+
+@router.get("/recent", response_model=list[EmergencySummary])
+def get_recent_emergencies(limit: int = 4) -> list[EmergencySummary]:
+    """Lista emergencias recientes sin consultar todo el historial."""
+    try:
+        return emergency_service.list_recent(limit)
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="No fue posible obtener las emergencias recientes",
         ) from exc
 
 

--- a/backend/app/modules/emergencies/schemas.py
+++ b/backend/app/modules/emergencies/schemas.py
@@ -42,6 +42,15 @@ class EmergencyStatusUpdate(BaseModel):
     comment: str | None = None
 
 
+class EmergencySummaryStats(BaseModel):
+    """Contadores agregados para el dashboard desktop."""
+
+    pendiente: int
+    en_revision: int
+    atendido: int = 0
+    resuelto: int
+
+
 class EmergencySummary(BaseModel):
     """Resumen de una emergencia para listados y paneles.
 

--- a/backend/app/modules/emergencies/service.py
+++ b/backend/app/modules/emergencies/service.py
@@ -6,6 +6,7 @@ from app.modules.emergencies.schemas import (
     EmergencyCreate,
     EmergencyStatusUpdate,
     EmergencySummary,
+    EmergencySummaryStats,
 )
 
 
@@ -54,6 +55,15 @@ class EmergencyService:
     def list_emergencies(self) -> list[EmergencySummary]:
         """Retorna emergencias desde el repositorio cuando exista persistencia."""
         return self.repository.list_emergencies()
+
+    def get_summary(self) -> EmergencySummaryStats:
+        """Retorna contadores agregados por estado."""
+        return self.repository.get_summary()
+
+    def list_recent(self, limit: int = 4) -> list[EmergencySummary]:
+        """Retorna emergencias recientes con un limite acotado."""
+        safe_limit = max(1, min(limit, 20))
+        return self.repository.list_recent(safe_limit)
 
     def get_catalogs(self) -> EmergencyCatalogs:
         """Retorna catalogos fijos sin consultar la base de datos."""

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -69,9 +69,19 @@ ApiClient → FastAPI` y consume:
 
 - `GET /api/v1/emergencies/catalogs` para cargar tipos y niveles válidos.
 - `POST /api/v1/emergencies/` para registrar emergencias reales.
-- `GET /api/v1/emergencies/` para refrescar dashboard y listado.
 - `PATCH /api/v1/emergencies/{emergency_id}/status` para cambiar estados reales
   desde el panel administrador.
+
+El dashboard consume endpoints optimizados para no descargar el listado completo
+al cargar KPIs y reportes recientes:
+
+- `GET /api/v1/emergencies/summary` para los contadores por estado.
+- `GET /api/v1/emergencies/recent?limit=4` para la sección de reportes
+  recientes.
+
+El listado general de emergencias sigue usando:
+
+- `GET /api/v1/emergencies/`
 
 El formulario de usuarios usa el flujo `Vista → UserController → ApiClient →
 FastAPI` y consume:

--- a/desktop/src/controllers/emergency_controller.py
+++ b/desktop/src/controllers/emergency_controller.py
@@ -49,6 +49,13 @@ STATUS_OPTIONS = [
     {"value": "resuelto", "label": "Resuelto"},
 ]
 
+DASHBOARD_STATUS_KEYS = {
+    EstadoEmergencia.PENDIENTE: "pendiente",
+    EstadoEmergencia.EN_REVISION: "en_revision",
+    EstadoEmergencia.ATENDIDO: "atendido",
+    EstadoEmergencia.RESUELTO: "resuelto",
+}
+
 BACKEND_TYPE_BY_ENUM = {
     TipoEmergencia.ROBO: "robo",
     TipoEmergencia.INCENDIO: "incendio",
@@ -232,6 +239,79 @@ class EmergencyController:
                 1 for e in datos if e.estado == EstadoEmergencia.RESUELTO
             ),
         }
+
+    def resumen_dashboard(self) -> dict[EstadoEmergencia, int]:
+        """Obtiene contadores optimizados para el dashboard con fallback seguro."""
+        self.backend_error = None
+        if self._api is not None:
+            datos = self._api.get_emergencies_summary()
+            if isinstance(datos, dict):
+                try:
+                    return self._parsear_resumen_dashboard(datos)
+                except (TypeError, ValueError):
+                    self.backend_error = (
+                        "El backend respondió, pero no se pudo interpretar "
+                        "el resumen de emergencias."
+                    )
+            else:
+                self.backend_error = (
+                    "No se pudo obtener el resumen optimizado del dashboard. "
+                    "Se usará el listado completo como respaldo."
+                )
+
+        error_resumen = self.backend_error
+        emergencias = self.listar()
+        if error_resumen and not self.backend_error:
+            self.backend_error = error_resumen
+        return self.estadisticas(emergencias)
+
+    def emergencias_recientes(self, limit: int = 4) -> list[Emergencia]:
+        """Obtiene reportes recientes optimizados para el dashboard."""
+        safe_limit = max(1, min(limit, 20))
+        if self._api is not None:
+            datos = self._api.get_recent_emergencies(safe_limit)
+            if datos is not None:
+                emergencias = self._parsear_emergencias(datos)
+                if emergencias or datos == []:
+                    self._actualizar_cache_recientes(emergencias)
+                    return emergencias
+
+                self.backend_error = (
+                    "El backend respondió, pero no se pudieron interpretar "
+                    "las emergencias recientes."
+                )
+            elif not self.backend_error:
+                self.backend_error = (
+                    "No se pudieron obtener las emergencias recientes. "
+                    "Se usará el listado completo como respaldo."
+                )
+
+        if self._ultima_lista:
+            return self._ultima_lista[:safe_limit]
+
+        error_recientes = self.backend_error
+        emergencias = self.listar()
+        if error_recientes and not self.backend_error:
+            self.backend_error = error_recientes
+        return emergencias[:safe_limit]
+
+    def _parsear_resumen_dashboard(
+        self,
+        datos: dict,
+    ) -> dict[EstadoEmergencia, int]:
+        stats = {estado: 0 for estado in DASHBOARD_STATUS_KEYS}
+        for estado, key in DASHBOARD_STATUS_KEYS.items():
+            stats[estado] = int(datos.get(key, 0) or 0)
+        return stats
+
+    def _actualizar_cache_recientes(self, emergencias: list[Emergencia]) -> None:
+        ids_recientes = {emergencia.id for emergencia in emergencias}
+        anteriores = [
+            emergencia
+            for emergencia in self._ultima_lista
+            if emergencia.id not in ids_recientes
+        ]
+        self._ultima_lista = emergencias + anteriores
 
     def registrar(
         self,

--- a/desktop/src/services/api_client.py
+++ b/desktop/src/services/api_client.py
@@ -50,6 +50,23 @@ class ApiClient:
         except ApiClientError:
             return None
 
+    def get_emergencies_summary(self) -> dict | None:
+        """Obtiene contadores agregados para el dashboard."""
+        try:
+            return self._request_json("GET", "/api/v1/emergencies/summary")
+        except ApiClientError:
+            return None
+
+    def get_recent_emergencies(self, limit: int = 4) -> list[dict] | None:
+        """Obtiene emergencias recientes para el dashboard."""
+        try:
+            return self._request_json(
+                "GET",
+                f"/api/v1/emergencies/recent?limit={limit}",
+            )
+        except ApiClientError:
+            return None
+
     def get_emergency_catalogs(self) -> dict:
         """Obtiene los catalogos validos para registrar emergencias."""
         return self._request_json("GET", "/api/v1/emergencies/catalogs")

--- a/desktop/src/views/dashboard_view.py
+++ b/desktop/src/views/dashboard_view.py
@@ -370,8 +370,8 @@ class DashboardView(QWidget):
     def refrescar(self) -> None:
         self.lbl_error_backend.setVisible(False)
 
-        emergencias = self._controller.listar()
-        stats = self._controller.estadisticas(emergencias)
+        stats = self._controller.resumen_dashboard()
+        recientes = self._controller.emergencias_recientes(limit=4)
 
         self.kpi_pendientes[1].setText(str(stats[EstadoEmergencia.PENDIENTE]))
         self.kpi_revision[1].setText(str(stats[EstadoEmergencia.EN_REVISION]))
@@ -383,8 +383,6 @@ class DashboardView(QWidget):
             item = self.recientes_box.takeAt(0)
             if item.widget():
                 item.widget().deleteLater()
-
-        recientes = emergencias[:4]
 
         if self._controller.backend_error:
             self.lbl_error_backend.setText(f"⚠️ {self._controller.backend_error}")


### PR DESCRIPTION
## Resumen

Este PR optimiza la carga de datos del dashboard desktop separando la información necesaria en endpoints específicos del backend.

Antes, el dashboard consultaba `GET /api/v1/emergencies/` completo para calcular KPIs y mostrar los 4 reportes recientes. Ahora usa endpoints más livianos:

- `GET /api/v1/emergencies/summary`
- `GET /api/v1/emergencies/recent?limit=4`

El listado general de reportes sigue usando `GET /api/v1/emergencies/`.

## Cambios principales

- Se agregó `EmergencySummaryStats`.
- Se agregó `GET /api/v1/emergencies/summary`.
- Se agregó `GET /api/v1/emergencies/recent?limit=4`.
- Se acotó `limit` entre 1 y 20.
- Las rutas fijas quedaron antes de `/{emergency_id}` para evitar conflicto.
- Se agregaron métodos nuevos en `ApiClient`.
- Se agregaron métodos optimizados en `EmergencyController`.
- `DashboardView.refrescar()` ahora usa summary y recent en vez del listado completo.
- Se actualizaron los README de backend y desktop.

## Pruebas realizadas

- [x] `backend\.venv\Scripts\python.exe -m compileall backend\app`
- [x] `desktop\.venv\Scripts\python.exe -m compileall desktop\src`
- [x] `git diff --check`
- [x] Probado `GET /api/v1/emergencies/summary`
- [x] Probado `GET /api/v1/emergencies/recent?limit=4`
- [x] Probado `GET /api/v1/emergencies/recent?limit=1`
- [x] Probado `GET /api/v1/emergencies/recent?limit=20`
- [x] Probado `GET /api/v1/emergencies/recent?limit=999`
- [x] Probado `GET /api/v1/emergencies/{emergency_id}`
- [x] Probado `GET /api/v1/emergencies/catalogs`
- [x] Verificado que el dashboard carga KPIs y reportes recientes.
- [x] Verificado que el listado general sigue funcionando.

## Nota

Esta mejora optimiza la arquitectura y reduce la cantidad de datos consultados por el dashboard. La mejora visible de percepción de carga se abordará en una siguiente Issue mediante carga en segundo plano.

Closes #65 