### PR TITLE
feat: load dashboard data in background

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -79,6 +79,11 @@ al cargar KPIs y reportes recientes:
 - `GET /api/v1/emergencies/recent?limit=4` para la sección de reportes
   recientes.
 
+La vista del dashboard inicia esa carga en segundo plano con `QThread` y un
+worker de datos. Primero muestra la interfaz con un estado temporal de carga y
+luego actualiza KPIs, reportes recientes y mensajes de error desde el hilo
+principal de PySide6.
+
 El listado general de emergencias sigue usando:
 
 - `GET /api/v1/emergencies/`

--- a/desktop/src/views/dashboard_view.py
+++ b/desktop/src/views/dashboard_view.py
@@ -5,7 +5,7 @@ rápidos a las acciones más usadas y los reportes más recientes. Toda la
 información se obtiene a través del `EmergencyController`.
 """
 
-from PySide6.QtCore import Qt, Signal
+from PySide6.QtCore import QObject, Qt, QThread, Signal, Slot
 from PySide6.QtWidgets import (
     QFrame,
     QGridLayout,
@@ -21,6 +21,30 @@ from src.models.entities import EstadoEmergencia, Usuario
 from src.widgets.badges import crear_badge_estado
 
 
+class DashboardDataWorker(QObject):
+    """Carga datos del dashboard fuera del hilo principal de PySide6."""
+
+    finished = Signal(object, object, object)
+    failed = Signal(str)
+    completed = Signal()
+
+    def __init__(self, controller: EmergencyController) -> None:
+        super().__init__()
+        self._controller = controller
+
+    @Slot()
+    def run(self) -> None:
+        try:
+            stats = self._controller.resumen_dashboard()
+            recientes = self._controller.emergencias_recientes(limit=4)
+            backend_error = self._controller.backend_error
+            self.finished.emit(stats, recientes, backend_error)
+        except Exception as exc:
+            self.failed.emit(str(exc))
+        finally:
+            self.completed.emit()
+
+
 class DashboardView(QWidget):
     """Panel principal con estadísticas y atajos."""
 
@@ -32,6 +56,9 @@ class DashboardView(QWidget):
         self.setWindowTitle("VecinoSeguro · Panel")
         self._controller = emergency_controller
         self._usuario: Usuario | None = None
+        self._cargando_dashboard = False
+        self._dashboard_thread: QThread | None = None
+        self._dashboard_worker: DashboardDataWorker | None = None
         self._build_ui()
 
     def _build_ui(self) -> None:
@@ -285,6 +312,41 @@ class DashboardView(QWidget):
 
         return card
 
+    def _mk_loading_recent_reports(self) -> QFrame:
+        """Construye el bloque visual para la carga de reportes recientes."""
+        card = QFrame()
+        card.setObjectName("loadingRecentReports")
+        card.setMinimumHeight(96)
+        card.setStyleSheet(
+            "QFrame#loadingRecentReports {"
+            "background-color: #FFFFFF;"
+            "border: 1px solid #D9E2EC;"
+            "border-radius: 10px;"
+            "}"
+        )
+
+        layout = QVBoxLayout(card)
+        layout.setContentsMargins(24, 20, 24, 20)
+        layout.setSpacing(6)
+
+        titulo = QLabel("Cargando información...")
+        titulo.setAlignment(Qt.AlignCenter)
+        titulo.setStyleSheet(
+            "font-size: 14px; font-weight: 700; color: #102A43;"
+            "background: transparent; border: none;"
+        )
+        layout.addWidget(titulo)
+
+        descripcion = QLabel("Actualizando KPIs y reportes recientes.")
+        descripcion.setAlignment(Qt.AlignCenter)
+        descripcion.setStyleSheet(
+            "font-size: 12px; color: #52616B;"
+            "background: transparent; border: none;"
+        )
+        layout.addWidget(descripcion)
+
+        return card
+
     def _mk_reciente_row(self, emergencia) -> QFrame:
         f = QFrame()
         f.setObjectName("recentRow")
@@ -368,25 +430,60 @@ class DashboardView(QWidget):
         self.lbl_subtitulo.setText(f"Sesión iniciada como {rol_texto}")
 
     def refrescar(self) -> None:
+        if self._cargando_dashboard:
+            return
+
+        self._cargando_dashboard = True
+        self._mostrar_carga_dashboard()
+
+        thread = QThread(self)
+        worker = DashboardDataWorker(self._controller)
+        worker.moveToThread(thread)
+
+        thread.started.connect(worker.run)
+        worker.finished.connect(self._aplicar_datos_dashboard)
+        worker.failed.connect(self._mostrar_error_carga_dashboard)
+        worker.completed.connect(thread.quit)
+        worker.completed.connect(worker.deleteLater)
+        thread.finished.connect(self._finalizar_carga_dashboard)
+
+        self._dashboard_thread = thread
+        self._dashboard_worker = worker
+        thread.start()
+
+    def _mostrar_carga_dashboard(self) -> None:
         self.lbl_error_backend.setVisible(False)
+        self.kpi_pendientes[1].setText("0")
+        self.kpi_revision[1].setText("0")
+        self.kpi_atendidos[1].setText("0")
+        self.kpi_resueltos[1].setText("0")
+        self._limpiar_reportes_recientes()
+        self.recientes_box.addWidget(self._mk_loading_recent_reports())
 
-        stats = self._controller.resumen_dashboard()
-        recientes = self._controller.emergencias_recientes(limit=4)
+    def _aplicar_datos_dashboard(
+        self,
+        stats: object,
+        recientes: object,
+        backend_error: object,
+    ) -> None:
+        stats = stats if isinstance(stats, dict) else {}
+        recientes = recientes if isinstance(recientes, list) else []
+        self.kpi_pendientes[1].setText(
+            str(stats.get(EstadoEmergencia.PENDIENTE, 0))
+        )
+        self.kpi_revision[1].setText(
+            str(stats.get(EstadoEmergencia.EN_REVISION, 0))
+        )
+        self.kpi_atendidos[1].setText(str(stats.get(EstadoEmergencia.ATENDIDO, 0)))
+        self.kpi_resueltos[1].setText(str(stats.get(EstadoEmergencia.RESUELTO, 0)))
 
-        self.kpi_pendientes[1].setText(str(stats[EstadoEmergencia.PENDIENTE]))
-        self.kpi_revision[1].setText(str(stats[EstadoEmergencia.EN_REVISION]))
-        self.kpi_atendidos[1].setText(str(stats[EstadoEmergencia.ATENDIDO]))
-        self.kpi_resueltos[1].setText(str(stats[EstadoEmergencia.RESUELTO]))
+        self._limpiar_reportes_recientes()
 
-        # Limpiar y recargar las filas de reportes recientes
-        while self.recientes_box.count():
-            item = self.recientes_box.takeAt(0)
-            if item.widget():
-                item.widget().deleteLater()
-
-        if self._controller.backend_error:
-            self.lbl_error_backend.setText(f"⚠️ {self._controller.backend_error}")
+        if backend_error:
+            self.lbl_error_backend.setText(f"⚠️ {backend_error}")
             self.lbl_error_backend.setVisible(True)
+        else:
+            self.lbl_error_backend.setVisible(False)
 
         if not recientes:
             self.recientes_box.addWidget(self._mk_empty_recent_reports())
@@ -394,3 +491,40 @@ class DashboardView(QWidget):
 
         for em in recientes:
             self.recientes_box.addWidget(self._mk_reciente_row(em))
+
+    def _mostrar_error_carga_dashboard(self, mensaje: str) -> None:
+        self._limpiar_reportes_recientes()
+        self.recientes_box.addWidget(self._mk_empty_recent_reports())
+        self.lbl_error_backend.setText(
+            f"⚠️ No fue posible cargar el dashboard: {mensaje}"
+        )
+        self.lbl_error_backend.setVisible(True)
+
+    def _limpiar_reportes_recientes(self) -> None:
+        while self.recientes_box.count():
+            item = self.recientes_box.takeAt(0)
+            if item.widget():
+                item.widget().deleteLater()
+
+    def _finalizar_carga_dashboard(self) -> None:
+        self._cargando_dashboard = False
+        if self._dashboard_thread is not None:
+            self._dashboard_thread.deleteLater()
+        self._dashboard_thread = None
+        self._dashboard_worker = None
+
+    def detener_carga(self) -> None:
+        """Espera el cierre ordenado del worker si la ventana se destruye."""
+        thread = self._dashboard_thread
+        if thread is not None and thread.isRunning():
+            thread.quit()
+            thread.wait()
+        if thread is not None:
+            thread.deleteLater()
+        self._cargando_dashboard = False
+        self._dashboard_worker = None
+        self._dashboard_thread = None
+
+    def closeEvent(self, event) -> None:
+        self.detener_carga()
+        super().closeEvent(event)

--- a/desktop/src/views/main_window.py
+++ b/desktop/src/views/main_window.py
@@ -7,7 +7,7 @@ listado de reportes. Coordina la sesión a través del `AuthController`.
 
 from pathlib import Path
 
-from PySide6.QtCore import QSize, Qt
+from PySide6.QtCore import QSize, Qt, QTimer
 from PySide6.QtSvgWidgets import QSvgWidget
 from PySide6.QtWidgets import (
     QFrame,
@@ -210,10 +210,9 @@ class MainWindow(QMainWindow):
         )
         self.list_view.cambio_realizado.connect(self.dashboard.refrescar)
 
-        self._actualizar_estado_backend()
-
         root.addWidget(self.sidebar)
         root.addWidget(self.content_area, 1)
+        QTimer.singleShot(100, self._actualizar_estado_backend)
 
     def _mk_sidebar_section(self, texto: str) -> QLabel:
         l = QLabel(texto)
@@ -284,8 +283,13 @@ class MainWindow(QMainWindow):
             self.lbl_titulo_pagina.setText("Registrar usuario")
 
     def _cerrar_sesion(self) -> None:
+        self.dashboard.detener_carga()
         self._auth.logout()
         self._on_logout()
+
+    def closeEvent(self, event) -> None:
+        self.dashboard.detener_carga()
+        super().closeEvent(event)
 
     def _es_admin(self) -> bool:
         return self._usuario is not None and self._usuario.rol == Rol.ADMIN


### PR DESCRIPTION
## Resumen

Este PR mejora la percepción de carga inicial del dashboard desktop implementando carga de datos en segundo plano con `QThread`.

Ahora la ventana principal puede mostrarse primero, mientras el dashboard presenta un estado temporal de carga y obtiene los datos optimizados sin bloquear visualmente la interfaz.

## Cambios principales

- Se agregó `DashboardDataWorker` basado en `QObject`.
- Se usa `QThread` para cargar datos del dashboard fuera del hilo principal.
- `DashboardView.refrescar()` ahora muestra un estado `Cargando información...`.
- Los KPIs se inicializan temporalmente en `0` mientras llegan los datos.
- Los reportes recientes se actualizan al recibir la respuesta del worker.
- Los errores se muestran de forma controlada en el dashboard.
- Se evita lanzar múltiples cargas simultáneas mediante `_cargando_dashboard`.
- Se limpia el hilo al terminar la carga.
- Se detiene la carga al cerrar sesión o cerrar la ventana.
- Se difiere la actualización del chip de backend con `QTimer.singleShot(...)`.
- Se actualizó el README desktop.

## Pruebas realizadas

- [x] Ejecutado `desktop\.venv\Scripts\python.exe -m compileall desktop\src` sin errores.
- [x] Ejecutado `git diff --check` sin errores.
- [x] Verificado que solo se modifican archivos desktop.
- [x] Probado login con backend encendido.
- [x] Verificado que el dashboard muestra `Cargando información...`.
- [x] Verificado que KPIs y reportes recientes se cargan correctamente.
- [x] Verificado que el listado general de reportes sigue funcionando.
- [x] Verificado cambio de estado de emergencia.
- [x] Verificado cierre de sesión mientras el dashboard está cargando.
- [x] Probado comportamiento con backend apagado.
- [x] Verificado que la app no se congela y muestra error controlado.

## Alcance

Este PR solo modifica la carga visual y técnica del dashboard desktop.

## No se modificó

- Backend
- Mobile
- Database
- Login
- Registro de usuarios
- Creación de emergencias
- Endpoints existentes

## Nota

Esta mejora complementa la optimización anterior basada en endpoints específicos:

- `GET /api/v1/emergencies/summary`
- `GET /api/v1/emergencies/recent?limit=4`

La mejora anterior redujo la cantidad de datos consultados. Este PR mejora la experiencia visual evitando que la carga del dashboard bloquee la interfaz.

Closes #67 