### PR TITLE
perf: add temporary dashboard cache

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -84,6 +84,12 @@ worker de datos. Primero muestra la interfaz con un estado temporal de carga y
 luego actualiza KPIs, reportes recientes y mensajes de error desde el hilo
 principal de PySide6.
 
+El controlador desktop reutiliza durante pocos segundos los datos optimizados
+del dashboard para evitar consultas repetidas cuando el usuario vuelve rápido a
+esa vista. Esta caché temporal se invalida al registrar una emergencia o al
+cambiar correctamente el estado de un reporte, de modo que los KPIs y reportes
+recientes reflejen los cambios relevantes.
+
 El listado general de emergencias sigue usando:
 
 - `GET /api/v1/emergencies/`

--- a/desktop/src/controllers/emergency_controller.py
+++ b/desktop/src/controllers/emergency_controller.py
@@ -10,6 +10,7 @@ estado de los reportes.
 """
 
 from datetime import datetime
+from time import monotonic
 from typing import Optional
 
 from src.models.entities import (
@@ -55,6 +56,7 @@ DASHBOARD_STATUS_KEYS = {
     EstadoEmergencia.ATENDIDO: "atendido",
     EstadoEmergencia.RESUELTO: "resuelto",
 }
+DASHBOARD_CACHE_TTL_SECONDS = 5
 
 BACKEND_TYPE_BY_ENUM = {
     TipoEmergencia.ROBO: "robo",
@@ -101,6 +103,11 @@ class EmergencyController:
         self._api = api_client
         self.backend_error: str | None = None
         self._ultima_lista: list[Emergencia] = []
+        self._dashboard_summary_cache: dict[EstadoEmergencia, int] | None = None
+        self._dashboard_summary_cache_time: float | None = None
+        self._dashboard_recent_cache: list[Emergencia] | None = None
+        self._dashboard_recent_cache_time: float | None = None
+        self._dashboard_recent_cache_limit: int | None = None
 
     # ------------------------------------------------------------------
     # API base del stub original (firma compatible)
@@ -124,7 +131,9 @@ class EmergencyController:
             nombre_reportante=payload["nombre_reportante"],
             fecha_reporte=datetime.now(),
         )
-        return self._repo.save(nueva).to_dict()
+        guardada = self._repo.save(nueva)
+        self._invalidar_cache_dashboard()
+        return guardada.to_dict()
 
     # ------------------------------------------------------------------
     # API extendida para uso desde las vistas
@@ -243,11 +252,20 @@ class EmergencyController:
     def resumen_dashboard(self) -> dict[EstadoEmergencia, int]:
         """Obtiene contadores optimizados para el dashboard con fallback seguro."""
         self.backend_error = None
+        if (
+            self._dashboard_summary_cache is not None
+            and self._cache_dashboard_valida(self._dashboard_summary_cache_time)
+        ):
+            return dict(self._dashboard_summary_cache)
+
         if self._api is not None:
             datos = self._api.get_emergencies_summary()
             if isinstance(datos, dict):
                 try:
-                    return self._parsear_resumen_dashboard(datos)
+                    resumen = self._parsear_resumen_dashboard(datos)
+                    self._dashboard_summary_cache = dict(resumen)
+                    self._dashboard_summary_cache_time = monotonic()
+                    return resumen
                 except (TypeError, ValueError):
                     self.backend_error = (
                         "El backend respondió, pero no se pudo interpretar "
@@ -268,11 +286,21 @@ class EmergencyController:
     def emergencias_recientes(self, limit: int = 4) -> list[Emergencia]:
         """Obtiene reportes recientes optimizados para el dashboard."""
         safe_limit = max(1, min(limit, 20))
+        if (
+            self._dashboard_recent_cache is not None
+            and self._dashboard_recent_cache_limit == safe_limit
+            and self._cache_dashboard_valida(self._dashboard_recent_cache_time)
+        ):
+            return list(self._dashboard_recent_cache)
+
         if self._api is not None:
             datos = self._api.get_recent_emergencies(safe_limit)
             if datos is not None:
                 emergencias = self._parsear_emergencias(datos)
                 if emergencias or datos == []:
+                    self._dashboard_recent_cache = list(emergencias)
+                    self._dashboard_recent_cache_time = monotonic()
+                    self._dashboard_recent_cache_limit = safe_limit
                     self._actualizar_cache_recientes(emergencias)
                     return emergencias
 
@@ -303,6 +331,18 @@ class EmergencyController:
         for estado, key in DASHBOARD_STATUS_KEYS.items():
             stats[estado] = int(datos.get(key, 0) or 0)
         return stats
+
+    def _cache_dashboard_valida(self, cache_time: float | None) -> bool:
+        if cache_time is None:
+            return False
+        return monotonic() - cache_time <= DASHBOARD_CACHE_TTL_SECONDS
+
+    def _invalidar_cache_dashboard(self) -> None:
+        self._dashboard_summary_cache = None
+        self._dashboard_summary_cache_time = None
+        self._dashboard_recent_cache = None
+        self._dashboard_recent_cache_time = None
+        self._dashboard_recent_cache_limit = None
 
     def _actualizar_cache_recientes(self, emergencias: list[Emergencia]) -> None:
         ids_recientes = {emergencia.id for emergencia in emergencias}
@@ -361,6 +401,7 @@ class EmergencyController:
             try:
                 creada = self._api.create_emergency(payload)
                 emergencia = self._parsear_emergencia_backend(creada, usuario)
+                self._invalidar_cache_dashboard()
                 return True, f"Emergencia #{emergencia.id} registrada.", emergencia
             except ApiClientError as exc:
                 return False, exc.message, None
@@ -384,6 +425,7 @@ class EmergencyController:
             fecha_reporte=datetime.now(),
         )
         guardada = self._repo.save(nueva)
+        self._invalidar_cache_dashboard()
         return True, f"Emergencia #{guardada.id} registrada.", guardada
 
     def _catalogos_validos(self, catalogos: object) -> bool:
@@ -476,6 +518,7 @@ class EmergencyController:
                 )
                 emergencia = self._parsear_emergencia_backend(actualizada)
                 self._actualizar_cache(emergencia)
+                self._invalidar_cache_dashboard()
                 return True, f"Estado actualizado a '{estado_normalizado.value}'."
             except ApiClientError as exc:
                 return False, self._mensaje_api_error(exc)
@@ -494,4 +537,5 @@ class EmergencyController:
             emergencia.observaciones = observaciones
         self._repo.save(emergencia)
         self._actualizar_cache(emergencia)
+        self._invalidar_cache_dashboard()
         return True, f"Estado actualizado a '{estado_normalizado.value}'."


### PR DESCRIPTION
## Resumen

Este PR agrega una caché temporal corta para los datos optimizados del dashboard desktop.

La mejora evita consultas repetidas innecesarias cuando el usuario vuelve rápidamente al dashboard, reutilizando durante pocos segundos los datos de:

- `GET /api/v1/emergencies/summary`
- `GET /api/v1/emergencies/recent?limit=4`

## Cambios principales

- Se agregó `DASHBOARD_CACHE_TTL_SECONDS = 5`.
- Se agregó caché temporal para el resumen del dashboard.
- Se agregó caché temporal para emergencias recientes.
- La caché de recientes considera el `limit`.
- Se usa `time.monotonic()` para validar expiración.
- La caché se invalida al registrar una emergencia.
- La caché se invalida al cambiar estado de una emergencia.
- Se actualizó el README desktop.

## Pruebas realizadas

- [x] Compilación desktop sin errores.
- [x] `git diff --check` sin errores.
- [x] Dashboard carga correctamente.
- [x] Al volver rápido al dashboard se reutiliza caché.
- [x] Tras expirar el TTL se vuelve a consultar.
- [x] Al crear emergencia se invalida caché.
- [x] Al cambiar estado se invalida caché.
- [x] No se modificó backend.
- [x] No se modificó mobile.
- [x] No se modificó database.

## Alcance

Este PR solo modifica la optimización interna del dashboard desktop.