### PR TITLE
feat: allow admins to delete emergency reports

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -156,6 +156,7 @@ GET /api/v1/emergencies/catalogs
 GET /api/v1/emergencies/{emergency_id}
 POST /api/v1/emergencies/
 PATCH /api/v1/emergencies/{emergency_id}/status
+DELETE /api/v1/emergencies/{emergency_id}
 GET /api/v1/reports/summary
 GET /api/v1/reports/dashboard-cards
 ```
@@ -470,6 +471,31 @@ Respuestas esperadas:
 * `400 Bad Request`
 * `404 Not Found`
 * `500 Internal Server Error`
+
+---
+
+## Eliminar emergencia
+
+```text
+DELETE /api/v1/emergencies/{emergency_id}
+```
+
+Elimina una emergencia real por ID desde la tabla `emergencies`. Su uso
+previsto es el panel administrador de la aplicación desktop.
+
+Respuestas esperadas:
+
+* `204 No Content`: emergencia eliminada correctamente, sin body de respuesta.
+* `404 Not Found`: la emergencia no existe.
+* `500 Internal Server Error`: error no controlado.
+
+No requiere cambios en `database/schema.sql`. Si existen registros asociados en
+`emergency_status_history`, la relación con `ON DELETE CASCADE` se encarga de
+eliminarlos junto con la emergencia.
+
+Limitación temporal: igual que otras acciones administrativas actuales, este
+endpoint aún no exige token ni permisos backend. En esta etapa el acceso se
+restringe desde la app desktop mostrando la acción solo a administradores.
 
 ---
 

--- a/backend/app/modules/emergencies/repository.py
+++ b/backend/app/modules/emergencies/repository.py
@@ -154,6 +154,32 @@ class EmergencyRepository:
                 cursor.close()
             connection.close()
 
+    def delete_by_id(self, emergency_id: int) -> bool:
+        """Elimina una emergencia por ID; retorna True si eliminó un registro."""
+        query = """
+            DELETE FROM emergencies
+            WHERE id = %s
+        """
+
+        connection = get_connection()
+        cursor = None
+        try:
+            cursor = connection.cursor()
+            cursor.execute(query, (emergency_id,))
+            deleted = cursor.rowcount > 0
+            connection.commit()
+            return deleted
+        except Exception:
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            raise
+        finally:
+            if cursor is not None:
+                cursor.close()
+            connection.close()
+
     def create_emergency(
         self,
         emergency_data: EmergencyCreate,

--- a/backend/app/modules/emergencies/router.py
+++ b/backend/app/modules/emergencies/router.py
@@ -91,6 +91,20 @@ def get_emergency_by_id(emergency_id: int) -> EmergencySummary:
         ) from exc
 
 
+@router.delete("/{emergency_id}", status_code=status.HTTP_204_NO_CONTENT)
+def delete_emergency(emergency_id: int) -> None:
+    """Elimina una emergencia por ID."""
+    try:
+        emergency_service.delete_emergency(emergency_id)
+    except EmergencyNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="No fue posible eliminar la emergencia",
+        ) from exc
+
+
 @router.post(
     "/",
     response_model=EmergencySummary,

--- a/backend/app/modules/emergencies/service.py
+++ b/backend/app/modules/emergencies/service.py
@@ -108,6 +108,12 @@ class EmergencyService:
 
         return updated
 
+    def delete_emergency(self, emergency_id: int) -> None:
+        """Elimina una emergencia existente."""
+        deleted = self.repository.delete_by_id(emergency_id)
+        if not deleted:
+            raise EmergencyNotFoundError("Emergencia no encontrada")
+
     def _validate_required_fields(self, emergency_data: EmergencyCreate) -> None:
         if emergency_data.user_id is None:
             raise EmergencyValidationError("El usuario es obligatorio")

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -54,7 +54,8 @@ datos reales del entorno local.
 - **Dashboard** con KPIs por estado, accesos rápidos y reportes recientes.
 - **Formulario de registro de emergencia** con validaciones de negocio.
 - **Listado de emergencias** con filtro por estado y panel de detalle.
-- **Detalle del reporte** con cambio de estado disponible solo para administradores.
+- **Detalle del reporte** con cambio de estado y eliminación con confirmación
+  disponibles solo para administradores.
 - **Registro básico de usuarios** visible solo para administradores.
 
 ## Integración con backend
@@ -71,6 +72,8 @@ ApiClient → FastAPI` y consume:
 - `POST /api/v1/emergencies/` para registrar emergencias reales.
 - `PATCH /api/v1/emergencies/{emergency_id}/status` para cambiar estados reales
   desde el panel administrador.
+- `DELETE /api/v1/emergencies/{emergency_id}` para eliminar reportes reales
+  desde el panel administrador, previa confirmación.
 
 El dashboard consume endpoints optimizados para no descargar el listado completo
 al cargar KPIs y reportes recientes:
@@ -86,9 +89,9 @@ principal de PySide6.
 
 El controlador desktop reutiliza durante pocos segundos los datos optimizados
 del dashboard para evitar consultas repetidas cuando el usuario vuelve rápido a
-esa vista. Esta caché temporal se invalida al registrar una emergencia o al
-cambiar correctamente el estado de un reporte, de modo que los KPIs y reportes
-recientes reflejen los cambios relevantes.
+esa vista. Esta caché temporal se invalida al registrar una emergencia, al
+cambiar correctamente el estado de un reporte o al eliminarlo, de modo que los
+KPIs y reportes recientes reflejen los cambios relevantes.
 
 El listado general de emergencias sigue usando:
 
@@ -104,10 +107,13 @@ El desktop no envía `status`; el backend asigna el estado inicial
 `pendiente`.
 
 En el listado de emergencias, los administradores pueden actualizar una
-emergencia real a `Pendiente`, `En revisión` o `Resuelto`. El estado `Atendido`
+emergencia real a `Pendiente`, `En revisión` o `Resuelto`, y también eliminar
+un reporte mediante confirmación. Tras una eliminación correcta, la tabla se
+refresca, el detalle vuelve al estado vacío, el contador total se recalcula y
+se emite `cambio_realizado` para actualizar el dashboard. El estado `Atendido`
 permanece solo en el mock local y no se envía al backend hasta que exista en la
-API. La observación opcional viaja como `comment`, pero el backend actual no la
-persiste; queda reservada para una futura issue de historial.
+API. El comentario de seguimiento viaja como `comment`, pero el backend actual
+no lo persiste; queda reservado para una futura issue de historial.
 
 Después de un login exitoso, el desktop construye un `Usuario` local con el
 `id`, `rut`, `full_name`, `email` y `role_id` retornados por el backend. El

--- a/desktop/src/controllers/emergency_controller.py
+++ b/desktop/src/controllers/emergency_controller.py
@@ -483,6 +483,40 @@ class EmergencyController:
             return "Emergencia no encontrada en el backend."
         return exc.message
 
+    def eliminar(self, emergencia_id: int) -> tuple[bool, str]:
+        """Elimina un reporte y limpia las caches relacionadas."""
+        if not isinstance(emergencia_id, int) or emergencia_id <= 0:
+            return False, "Debe seleccionar un reporte válido."
+
+        if self._api is not None:
+            try:
+                self._api.delete_emergency(emergencia_id)
+                self._ultima_lista = [
+                    emergencia
+                    for emergencia in self._ultima_lista
+                    if emergencia.id != emergencia_id
+                ]
+                self._invalidar_cache_dashboard()
+                return True, "Reporte eliminado correctamente."
+            except ApiClientError as exc:
+                return False, self._mensaje_api_error(exc)
+
+        delete_by_id = getattr(self._repo, "delete_by_id", None)
+        if not callable(delete_by_id):
+            return False, "La eliminación local no está disponible en este modo."
+
+        deleted = delete_by_id(emergencia_id)
+        if not deleted:
+            return False, "Emergencia no encontrada."
+
+        self._ultima_lista = [
+            emergencia
+            for emergencia in self._ultima_lista
+            if emergencia.id != emergencia_id
+        ]
+        self._invalidar_cache_dashboard()
+        return True, "Reporte eliminado correctamente."
+
     def cambiar_estado(
         self,
         emergencia_id: int,

--- a/desktop/src/services/api_client.py
+++ b/desktop/src/services/api_client.py
@@ -95,6 +95,32 @@ class ApiClient:
             json=payload,
         )
 
+    def delete_emergency(self, emergency_id: int) -> None:
+        """Elimina una emergencia real en el backend FastAPI."""
+        url = f"{self.base_url}/api/v1/emergencies/{emergency_id}"
+        try:
+            response = requests.delete(url, timeout=10)
+        except requests.Timeout as exc:
+            raise ApiClientError(
+                "No fue posible conectar con el backend. "
+                "La solicitud agotó el tiempo de espera."
+            ) from exc
+        except requests.ConnectionError as exc:
+            raise ApiClientError(
+                "No fue posible conectar con el backend. "
+                "Verifica que FastAPI esté en ejecución."
+            ) from exc
+        except requests.RequestException as exc:
+            raise ApiClientError(
+                "No fue posible conectar con el backend. "
+                "Verifica que FastAPI esté en ejecución."
+            ) from exc
+
+        if response.status_code >= 400:
+            detail = self._response_detail(response)
+            message = self._message_for_status(response.status_code)
+            raise ApiClientError(message, response.status_code, detail)
+
     def _request_json(self, method: str, path: str, **kwargs) -> dict | list[dict]:
         """Ejecuta una peticion HTTP y traduce errores a mensajes de usuario."""
         url = f"{self.base_url}{path}"

--- a/desktop/src/views/emergency_list_view.py
+++ b/desktop/src/views/emergency_list_view.py
@@ -204,7 +204,7 @@ class EmergencyListView(QWidget):
         adm_lay = QVBoxLayout(self.admin_panel)
         adm_lay.setContentsMargins(16, 14, 16, 14)
         adm_lay.setSpacing(10)
-        t_admin = QLabel("⚙ Acciones del administrador")
+        t_admin = QLabel("⚙ Gestión del reporte")
         t_admin.setStyleSheet(
             "color: #92400E; font-weight: 700; font-size: 12px; "
             "background: transparent; border: none;"
@@ -229,7 +229,7 @@ class EmergencyListView(QWidget):
         cambio_row.addWidget(self.cb_nuevo_estado)
         adm_lay.addLayout(cambio_row)
 
-        lbl_o = QLabel("Observación (opcional):")
+        lbl_o = QLabel("Comentario de seguimiento")
         lbl_o.setStyleSheet(
             "color: #52616B; font-size: 11px; font-weight: 600; "
             "background: transparent; border: none;"
@@ -238,7 +238,7 @@ class EmergencyListView(QWidget):
         self.input_obs = QTextEdit()
         self.input_obs.setMaximumHeight(60)
         self.input_obs.setPlaceholderText(
-            "Notas internas para el seguimiento del reporte…"
+            "Ej: Reporte revisado por administración vecinal."
         )
         adm_lay.addWidget(self.input_obs)
 
@@ -246,6 +246,12 @@ class EmergencyListView(QWidget):
         estilizar_boton(self.btn_actualizar, "primary")
         self.btn_actualizar.clicked.connect(self._actualizar_estado)
         adm_lay.addWidget(self.btn_actualizar)
+
+        self.btn_eliminar = QPushButton("Eliminar reporte")
+        estilizar_boton(self.btn_eliminar, "danger")
+        self.btn_eliminar.clicked.connect(self._eliminar_reporte)
+        adm_lay.addSpacing(4)
+        adm_lay.addWidget(self.btn_eliminar)
         lay.addWidget(self.admin_panel)
         lay.addStretch()
         return f
@@ -419,3 +425,30 @@ class EmergencyListView(QWidget):
                 self._mostrar_detalle(emergencia_id)
         else:
             QMessageBox.warning(self, "Error", msg)
+
+    def _eliminar_reporte(self) -> None:
+        if self._emergencia_seleccionada_id is None:
+            return
+
+        respuesta = QMessageBox.question(
+            self,
+            "Confirmar eliminación",
+            "¿Eliminar este reporte?\n\n"
+            "Esta acción quitará el reporte del sistema y no se podrá deshacer.",
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if respuesta != QMessageBox.StandardButton.Yes:
+            return
+
+        ok, msg = self._controller.eliminar(self._emergencia_seleccionada_id)
+        if not ok:
+            QMessageBox.warning(self, "No se pudo eliminar", msg)
+            return
+
+        QMessageBox.information(self, "Reporte eliminado", msg)
+        self.cambio_realizado.emit()
+        self._emergencia_seleccionada_id = None
+        self.tabla.clearSelection()
+        self.refrescar()
+        self.detalle_stack.setCurrentIndex(0)


### PR DESCRIPTION
## Resumen

Este PR agrega la funcionalidad para que los usuarios administradores puedan eliminar reportes de emergencia desde la aplicación desktop.

También mejora los textos del panel **Gestión del reporte**, reemplazando textos de desarrollo por mensajes más claros para el uso real de la aplicación.

## Cambios principales

- Se agregó `DELETE /api/v1/emergencies/{emergency_id}` en backend.
- El backend elimina emergencias reales desde MySQL/MariaDB.
- El endpoint responde `204 No Content` al eliminar correctamente.
- El endpoint responde `404 Not Found` si la emergencia no existe.
- Se agregó `ApiClient.delete_emergency(...)` en desktop.
- Se agregó `EmergencyController.eliminar(...)`.
- Se agregó botón **Eliminar reporte** en el panel administrador.
- La eliminación pide confirmación antes de ejecutarse.
- Después de eliminar, se refresca la tabla de reportes.
- Después de eliminar, el detalle vuelve al estado vacío.
- Después de eliminar, el contador total se recalcula.
- Después de eliminar, se emite `cambio_realizado` para actualizar el dashboard.
- Se invalida la caché temporal del dashboard al eliminar un reporte.
- Se mejoraron los textos del panel administrador:
  - `Acciones del administrador` → `Gestión del reporte`
  - `Observación (opcional):` → `Comentario de seguimiento`
  - Placeholder actualizado a un texto más natural.
- Se actualizaron los README de backend y desktop.

## Pruebas realizadas

- [x] `backend\.venv\Scripts\python.exe -m compileall backend\app`
- [x] `desktop\.venv\Scripts\python.exe -m compileall desktop\src`
- [x] `git diff --check`
- [x] Probado `DELETE /api/v1/emergencies/{emergency_id}` desde Swagger.
- [x] Verificado `204 No Content` al eliminar una emergencia existente.
- [x] Verificado `404 Not Found` al intentar eliminar una emergencia inexistente.
- [x] Verificado que la emergencia eliminada ya no aparece en `GET /api/v1/emergencies/`.
- [x] Verificado que `summary` y `recent` reflejan el cambio.
- [x] Probado desde desktop con usuario administrador.
- [x] Verificado que la eliminación pide confirmación.
- [x] Verificado que cancelar la confirmación no elimina el reporte.
- [x] Verificado que al confirmar se elimina el reporte.
- [x] Verificado que la tabla se refresca.
- [x] Verificado que el detalle vuelve al estado vacío.
- [x] Verificado que el dashboard se actualiza.
- [x] Verificado que usuario vecino no ve el panel administrador ni el botón de eliminación.

## Alcance

Este PR implementa eliminación de reportes de emergencia para administradores y mejora textos del panel administrativo en desktop.

## No se modificó

- Mobile
- Database
- Auth
- Users
- Reports
- Registro de usuarios
- Creación de emergencias
- Login