### PR TITLE
feat: open recent reports from dashboard

### DIFF
--- a/desktop/README.md
+++ b/desktop/README.md
@@ -52,6 +52,8 @@ datos reales del entorno local.
 - **Login** conectado al backend real, con validación de RUT (módulo 11) y
   mensajes de error claros.
 - **Dashboard** con KPIs por estado, accesos rápidos y reportes recientes.
+- Las tarjetas de reportes recientes del dashboard abren directamente el
+  detalle del reporte en la pantalla **Reportes**.
 - **Formulario de registro de emergencia** con validaciones de negocio.
 - **Listado de emergencias** con filtro por estado y panel de detalle.
 - **Detalle del reporte** con cambio de estado y eliminación con confirmación

--- a/desktop/src/views/dashboard_view.py
+++ b/desktop/src/views/dashboard_view.py
@@ -50,6 +50,7 @@ class DashboardView(QWidget):
 
     ir_a_registrar = Signal()
     ir_a_listado = Signal()
+    ir_a_reporte = Signal(int)
 
     def __init__(self, emergency_controller: EmergencyController) -> None:
         super().__init__()
@@ -351,6 +352,14 @@ class DashboardView(QWidget):
         f = QFrame()
         f.setObjectName("recentRow")
         f.setMinimumHeight(94)
+        f.setCursor(Qt.PointingHandCursor)
+        f.setToolTip("Abrir detalle del reporte")
+        emergencia_id = emergencia.id
+
+        def abrir_detalle(event, reporte_id=emergencia_id) -> None:
+            self.ir_a_reporte.emit(reporte_id)
+
+        f.mousePressEvent = abrir_detalle
 
         l = QHBoxLayout(f)
         l.setContentsMargins(16, 12, 16, 12)

--- a/desktop/src/views/emergency_list_view.py
+++ b/desktop/src/views/emergency_list_view.py
@@ -322,13 +322,45 @@ class EmergencyListView(QWidget):
 
         # Mantener selección si el id sigue presente
         if self._emergencia_seleccionada_id is not None:
-            for r in range(self.tabla.rowCount()):
-                item = self.tabla.item(r, 0)
-                if item and item.data(Qt.UserRole) == self._emergencia_seleccionada_id:
-                    self.tabla.selectRow(r)
-                    return
+            if self._seleccionar_fila_por_id(self._emergencia_seleccionada_id):
+                return
         self._emergencia_seleccionada_id = None
         self.detalle_stack.setCurrentIndex(0)
+
+    def seleccionar_reporte(self, emergencia_id: int) -> bool:
+        if self.cb_filtro.currentData() is not None:
+            self.cb_filtro.blockSignals(True)
+            self.cb_filtro.setCurrentIndex(0)
+            self.cb_filtro.blockSignals(False)
+
+        self.refrescar()
+        if not self._seleccionar_fila_por_id(emergencia_id, emitir_senial=False):
+            self._emergencia_seleccionada_id = None
+            self.tabla.clearSelection()
+            self.detalle_stack.setCurrentIndex(0)
+            return False
+
+        self._emergencia_seleccionada_id = emergencia_id
+        self._mostrar_detalle(emergencia_id)
+        return True
+
+    def _seleccionar_fila_por_id(
+        self,
+        emergencia_id: int,
+        *,
+        emitir_senial: bool = True,
+    ) -> bool:
+        for row in range(self.tabla.rowCount()):
+            item = self.tabla.item(row, 0)
+            if item and item.data(Qt.UserRole) == emergencia_id:
+                if not emitir_senial:
+                    senales_bloqueadas = self.tabla.blockSignals(True)
+                    self.tabla.selectRow(row)
+                    self.tabla.blockSignals(senales_bloqueadas)
+                    return True
+                self.tabla.selectRow(row)
+                return True
+        return False
 
     def _set_cell(self, row, col, texto, align=Qt.AlignLeft | Qt.AlignVCenter,
                   color: str | None = None, weight: int = 400, data=None) -> None:

--- a/desktop/src/views/main_window.py
+++ b/desktop/src/views/main_window.py
@@ -204,6 +204,7 @@ class MainWindow(QMainWindow):
         # Conexiones entre vistas
         self.dashboard.ir_a_registrar.connect(lambda: self.ir_a(self.PAG_FORM))
         self.dashboard.ir_a_listado.connect(lambda: self.ir_a(self.PAG_LIST))
+        self.dashboard.ir_a_reporte.connect(self._abrir_reporte_desde_dashboard)
         self.form_view.cancelado.connect(lambda: self.ir_a(self.PAG_DASH))
         self.form_view.emergencia_registrada.connect(
             lambda: self.ir_a(self.PAG_LIST)
@@ -281,6 +282,10 @@ class MainWindow(QMainWindow):
         elif indice == self.PAG_USERS:
             self.btn_users.setChecked(True)
             self.lbl_titulo_pagina.setText("Registrar usuario")
+
+    def _abrir_reporte_desde_dashboard(self, emergencia_id: int) -> None:
+        self.ir_a(self.PAG_LIST)
+        self.list_view.seleccionar_reporte(emergencia_id)
 
     def _cerrar_sesion(self) -> None:
         self.dashboard.detener_carga()


### PR DESCRIPTION
## Resumen

Este PR mejora la navegación desde el dashboard desktop permitiendo hacer clic en una tarjeta de **Reportes recientes** para abrir directamente el detalle del reporte en la pantalla **Reportes**.

## Cambios principales

- Se agregó la señal `ir_a_reporte` en `DashboardView`.
- Las tarjetas de reportes recientes ahora son clicables.
- Se agregó cursor de mano y tooltip en las tarjetas recientes.
- Al hacer clic en una tarjeta reciente, se navega automáticamente a **Reportes**.
- Se selecciona automáticamente el reporte correspondiente en la tabla.
- Se muestra el detalle del reporte en el panel derecho.
- Si hay un filtro activo en Reportes, se limpia para poder encontrar el reporte.
- Si el reporte ya no existe, se limpia la selección y se muestra el estado vacío.
- Se actualizó el README desktop.

## Pruebas realizadas

- [x] Compilación desktop sin errores.
- [x] `git diff --check` sin errores.
- [x] Login como administrador.
- [x] Click en reporte reciente desde dashboard.
- [x] Navegación correcta a Reportes.
- [x] Selección automática del reporte en la tabla.
- [x] Detalle mostrado correctamente.
- [x] Prueba con varias tarjetas recientes.
- [x] Prueba con filtro activo en Reportes.
- [x] Prueba con usuario vecino.
- [x] Verificado que no se modifica backend.
- [x] Verificado que no se modifica mobile.
- [x] Verificado que no se modifica database.

## Alcance

Este PR solo mejora la navegación desktop desde el dashboard hacia el detalle de reportes.

## No se modificó

- Backend
- Mobile
- Database
- Login
- Registro de usuarios
- Creación de emergencias
- Eliminación de reportes
- Cambio de estado