### PR TITLE
feat: edit users from admin desktop panel

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -150,6 +150,7 @@ GET /api/v1/system/info
 POST /api/v1/auth/login
 GET /api/v1/users/
 POST /api/v1/users/
+PATCH /api/v1/users/{user_id}
 GET /api/v1/emergencies/
 GET /api/v1/emergencies/summary
 GET /api/v1/emergencies/recent?limit=4
@@ -250,7 +251,7 @@ Body de prueba para vecino:
 
 # Gestión básica de usuarios
 
-El módulo `users` permite listar y crear usuarios reales desde el panel
+El módulo `users` permite listar, crear y editar usuarios reales desde el panel
 administrador desktop.
 
 ## Listar usuarios
@@ -346,6 +347,59 @@ Respuestas esperadas:
 
 Limitación temporal: este endpoint aún no exige token ni permisos backend. Por
 ahora el acceso se restringe desde la app desktop mostrando el formulario solo a
+usuarios con rol administrador. La autorización backend avanzada queda para una
+etapa posterior.
+
+## Editar usuarios
+
+Endpoint:
+
+```text
+PATCH /api/v1/users/{user_id}
+```
+
+Permite actualizar solo datos básicos del usuario:
+
+* nombre completo;
+* email;
+* rol.
+
+No permite editar RUT ni contraseña, y la respuesta nunca incluye `password` ni
+`password_hash`.
+
+Body de ejemplo:
+
+```json
+{
+  "full_name": "Nombre Actualizado",
+  "email": "correo.actualizado@vecinoseguro.cl",
+  "role_id": 2
+}
+```
+
+Respuesta segura:
+
+```json
+{
+  "id": 5,
+  "rut": "12345678-5",
+  "full_name": "Nombre Actualizado",
+  "email": "correo.actualizado@vecinoseguro.cl",
+  "role_id": 2,
+  "role": "vecino"
+}
+```
+
+Respuestas esperadas:
+
+* `200 OK`: usuario actualizado.
+* `400 Bad Request`: nombre, email o rol inválido.
+* `404 Not Found`: usuario inexistente.
+* `409 Conflict`: email perteneciente a otro usuario.
+* `500 Internal Server Error`: error no controlado.
+
+Limitación temporal: este endpoint aún no exige token ni permisos backend. Por
+ahora el acceso se restringe desde la app desktop mostrando la vista solo a
 usuarios con rol administrador. La autorización backend avanzada queda para una
 etapa posterior.
 
@@ -642,13 +696,16 @@ Ejemplo de respuesta:
 6. Probar `POST /api/v1/users/` con usuario vecino y administrador.
 7. Probar errores de RUT inválido, RUT duplicado, email duplicado y contraseña corta.
 8. Confirmar que la respuesta de creación no incluya `password_hash`.
-9. Probar `GET /api/v1/emergencies/`.
-10. Probar `GET /api/v1/emergencies/summary`.
-11. Probar `GET /api/v1/emergencies/recent?limit=4`.
-12. Probar `GET /api/v1/emergencies/catalogs`.
-13. Probar `GET /api/v1/reports/summary`.
-14. Probar `GET /api/v1/reports/dashboard-cards`.
-15. Verificar que las respuestas sean coherentes con los datos cargados desde `database/seed.sql`.
+9. Probar `PATCH /api/v1/users/{user_id}` con nombre, email y rol válidos.
+10. Probar errores de usuario inexistente, email duplicado y rol inválido.
+11. Confirmar que la respuesta de edición no incluya `password_hash`.
+12. Probar `GET /api/v1/emergencies/`.
+13. Probar `GET /api/v1/emergencies/summary`.
+14. Probar `GET /api/v1/emergencies/recent?limit=4`.
+15. Probar `GET /api/v1/emergencies/catalogs`.
+16. Probar `GET /api/v1/reports/summary`.
+17. Probar `GET /api/v1/reports/dashboard-cards`.
+18. Verificar que las respuestas sean coherentes con los datos cargados desde `database/seed.sql`.
 
 ---
 

--- a/backend/app/modules/users/repository.py
+++ b/backend/app/modules/users/repository.py
@@ -95,6 +95,63 @@ class UserRepository:
             if connection is not None:
                 connection.close()
 
+    def find_by_id(self, user_id: int) -> dict[str, Any] | None:
+        """Busca un usuario por ID sin retornar contraseña ni hash."""
+        query = """
+            SELECT
+                id,
+                rut,
+                full_name,
+                email,
+                role_id
+            FROM users
+            WHERE id = %s
+            LIMIT 1
+        """
+        connection = None
+        cursor = None
+        try:
+            connection = get_connection()
+            cursor = connection.cursor(dictionary=True)
+            cursor.execute(query, (user_id,))
+            return cursor.fetchone()
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if connection is not None:
+                connection.close()
+
+    def find_by_email_excluding_user(
+        self,
+        email: str,
+        user_id: int,
+    ) -> dict[str, Any] | None:
+        """Busca un email que pertenezca a otro usuario."""
+        query = """
+            SELECT
+                id,
+                rut,
+                full_name,
+                email,
+                role_id
+            FROM users
+            WHERE email = %s
+              AND id <> %s
+            LIMIT 1
+        """
+        connection = None
+        cursor = None
+        try:
+            connection = get_connection()
+            cursor = connection.cursor(dictionary=True)
+            cursor.execute(query, (email, user_id))
+            return cursor.fetchone()
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if connection is not None:
+                connection.close()
+
     def role_exists(self, role_id: int) -> bool:
         """Indica si el rol existe en la tabla roles."""
         query = "SELECT id FROM roles WHERE id = %s LIMIT 1"
@@ -158,6 +215,57 @@ class UserRepository:
                 raise RuntimeError("No fue posible recuperar el usuario creado")
 
             return UserCreateResponse(**row)
+        except Exception:
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            raise
+        finally:
+            if cursor is not None:
+                cursor.close()
+            connection.close()
+
+    def update_user(
+        self,
+        user_id: int,
+        full_name: str,
+        email: str,
+        role_id: int,
+    ) -> UserListItem | None:
+        """Actualiza datos básicos y retorna el usuario seguro actualizado."""
+        update_query = """
+            UPDATE users
+            SET full_name = %s,
+                email = %s,
+                role_id = %s
+            WHERE id = %s
+        """
+        select_query = """
+            SELECT
+                u.id,
+                u.rut,
+                u.full_name,
+                u.email,
+                u.role_id,
+                r.name AS role
+            FROM users u
+            INNER JOIN roles r ON r.id = u.role_id
+            WHERE u.id = %s
+            LIMIT 1
+        """
+        connection = get_connection()
+        cursor = None
+        try:
+            cursor = connection.cursor(dictionary=True)
+            cursor.execute(update_query, (full_name, email, role_id, user_id))
+            connection.commit()
+
+            cursor.execute(select_query, (user_id,))
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            return UserListItem(**row)
         except Exception:
             try:
                 connection.rollback()

--- a/backend/app/modules/users/router.py
+++ b/backend/app/modules/users/router.py
@@ -6,11 +6,13 @@ from app.modules.users.schemas import (
     UserCreateRequest,
     UserCreateResponse,
     UserListItem,
+    UserUpdateRequest,
 )
 from app.modules.users.service import (
     InvalidRoleError,
     InvalidUserDataError,
     UserAlreadyExistsError,
+    UserNotFoundError,
     UserService,
 )
 
@@ -47,4 +49,22 @@ def create_user(user_data: UserCreateRequest) -> UserCreateResponse:
         raise HTTPException(
             status_code=500,
             detail="No fue posible crear el usuario",
+        ) from exc
+
+
+@router.patch("/{user_id}", response_model=UserListItem)
+def update_user(user_id: int, user_data: UserUpdateRequest) -> UserListItem:
+    """Actualiza nombre, email y rol de un usuario existente."""
+    try:
+        return user_service.update_user(user_id, user_data)
+    except (InvalidUserDataError, InvalidRoleError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except UserNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except UserAlreadyExistsError as exc:
+        raise HTTPException(status_code=409, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="No fue posible actualizar el usuario",
         ) from exc

--- a/backend/app/modules/users/schemas.py
+++ b/backend/app/modules/users/schemas.py
@@ -33,6 +33,14 @@ class UserCreateRequest(BaseModel):
     role_id: int
 
 
+class UserUpdateRequest(BaseModel):
+    """Datos editables de un usuario existente."""
+
+    full_name: str = Field(...)
+    email: str = Field(...)
+    role_id: int
+
+
 class UserCreateResponse(BaseModel):
     """Respuesta segura para altas de usuario, sin contraseña ni hash."""
 

--- a/backend/app/modules/users/service.py
+++ b/backend/app/modules/users/service.py
@@ -8,6 +8,7 @@ from app.modules.users.schemas import (
     UserCreateRequest,
     UserCreateResponse,
     UserListItem,
+    UserUpdateRequest,
 )
 from app.shared.validators.rut_validator import normalize_rut, validate_rut
 
@@ -26,6 +27,10 @@ class UserAlreadyExistsError(ValueError):
 
 class InvalidRoleError(ValueError):
     """Indica que el rol solicitado no está permitido."""
+
+
+class UserNotFoundError(LookupError):
+    """Indica que el usuario solicitado no existe."""
 
 
 class UserService:
@@ -85,3 +90,50 @@ class UserService:
                     "Ya existe un usuario con ese RUT o email"
                 ) from exc
             raise
+
+    def update_user(
+        self,
+        user_id: int,
+        request: UserUpdateRequest,
+    ) -> UserListItem:
+        """Valida y actualiza nombre, email y rol de un usuario existente."""
+        if user_id <= 0:
+            raise InvalidUserDataError("ID de usuario inválido")
+
+        full_name = request.full_name.strip()
+        email = request.email.strip().lower()
+        role_id = request.role_id
+
+        if not full_name:
+            raise InvalidUserDataError("El nombre completo es obligatorio")
+        if not email:
+            raise InvalidUserDataError("El email es obligatorio")
+        if "@" not in email or "." not in email.rsplit("@", 1)[-1]:
+            raise InvalidUserDataError("El email no tiene un formato válido")
+        if role_id not in VALID_ROLE_IDS:
+            raise InvalidRoleError("Rol inválido. Use 1 para admin o 2 para vecino")
+        if not self.repository.role_exists(role_id):
+            raise InvalidRoleError("El rol indicado no existe")
+
+        if self.repository.find_by_id(user_id) is None:
+            raise UserNotFoundError("Usuario no encontrado")
+        if self.repository.find_by_email_excluding_user(email, user_id) is not None:
+            raise UserAlreadyExistsError("Ya existe otro usuario con ese email")
+
+        try:
+            updated = self.repository.update_user(
+                user_id=user_id,
+                full_name=full_name,
+                email=email,
+                role_id=role_id,
+            )
+        except IntegrityError as exc:
+            if getattr(exc, "errno", None) == 1062:
+                raise UserAlreadyExistsError(
+                    "Ya existe otro usuario con ese email"
+                ) from exc
+            raise
+
+        if updated is None:
+            raise UserNotFoundError("Usuario no encontrado")
+        return updated

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -59,7 +59,8 @@ datos reales del entorno local.
 - **Detalle del reporte** con cambio de estado y eliminación con confirmación
   disponibles solo para administradores.
 - **Gestión básica de usuarios** visible solo para administradores, con
-  creación de cuentas y listado de usuarios registrados.
+  creación de cuentas, listado de usuarios registrados y edición de nombre,
+  email y rol.
 
 ## Integración con backend
 
@@ -107,6 +108,8 @@ FastAPI` y consume:
   administrativa.
 - `POST /api/v1/users/` para registrar usuarios reales con RUT, nombre, email,
   contraseña inicial y rol.
+- `PATCH /api/v1/users/{user_id}` para editar nombre, email y rol de usuarios
+  existentes.
 
 El desktop no envía `status`; el backend asigna el estado inicial
 `pendiente`.
@@ -128,9 +131,11 @@ Los administradores ven el acceso lateral **Usuarios** y pueden crear cuentas
 con rol **Vecino** (`role_id=2`) o **Administrador** (`role_id=1`). En la misma
 vista pueden consultar una tabla de usuarios registrados con ID, RUT, nombre,
 email y rol; después de crear un usuario, el listado se actualiza para mostrar
-el nuevo registro. Los vecinos no ven ese acceso en la navegación normal. La
-contraseña inicial no se muestra ni se guarda en desktop; el backend la persiste
-como hash bcrypt.
+el nuevo registro. Al seleccionar una fila, pueden editar nombre completo,
+email y rol desde una sección separada. No se edita RUT, no se cambia
+contraseña y no se eliminan usuarios desde esta vista. Los vecinos no ven ese
+acceso en la navegación normal. La contraseña inicial no se muestra ni se guarda
+en desktop; el backend la persiste como hash bcrypt.
 
 Respuesta segura esperada desde `GET /api/v1/users/`:
 
@@ -148,6 +153,21 @@ Respuesta segura esperada desde `GET /api/v1/users/`:
 ```
 
 El listado no expone `password` ni `password_hash`.
+
+Respuesta segura esperada desde `PATCH /api/v1/users/{user_id}`:
+
+```json
+{
+  "id": 4,
+  "rut": "12345678-5",
+  "full_name": "Usuario Editado",
+  "email": "usuario.editado@vecinoseguro.cl",
+  "role_id": 2,
+  "role": "vecino"
+}
+```
+
+La edición básica no expone contraseñas ni hashes.
 
 Respuesta segura esperada desde `POST /api/v1/users/`:
 

--- a/desktop/src/controllers/user_controller.py
+++ b/desktop/src/controllers/user_controller.py
@@ -63,9 +63,51 @@ class UserController:
             return False, "No fue posible cargar el listado de usuarios.", []
         return True, "", usuarios
 
+    def editar_usuario(
+        self,
+        user_id: int,
+        full_name: str,
+        email: str,
+        role_id: int,
+    ) -> tuple[bool, str, dict | None]:
+        """Valida y solicita la edición básica de un usuario."""
+        nombre_limpio = full_name.strip()
+        email_limpio = email.strip().lower()
+
+        if user_id <= 0:
+            return False, "Debe seleccionar un usuario válido.", None
+        if not nombre_limpio:
+            return False, "El nombre completo es obligatorio.", None
+        if not email_limpio:
+            return False, "El email es obligatorio.", None
+        if "@" not in email_limpio or "." not in email_limpio.rsplit("@", 1)[-1]:
+            return False, "El email no tiene un formato válido.", None
+        if role_id not in VALID_ROLE_IDS:
+            return False, "Debe seleccionar un rol válido.", None
+
+        payload = {
+            "full_name": nombre_limpio,
+            "email": email_limpio,
+            "role_id": role_id,
+        }
+        try:
+            actualizado = self._api.update_user(user_id, payload)
+            return True, "Usuario actualizado correctamente.", actualizado
+        except ApiClientError as exc:
+            return False, self._mensaje_edicion_error(exc), None
+
     def _mensaje_api_error(self, exc: ApiClientError) -> str:
         if isinstance(exc.detail, str) and exc.detail:
             return exc.detail
         if exc.status_code == 409:
             return "Ya existe un usuario con ese RUT o email."
+        return exc.message
+
+    def _mensaje_edicion_error(self, exc: ApiClientError) -> str:
+        if isinstance(exc.detail, str) and exc.detail:
+            return exc.detail
+        if exc.status_code == 404:
+            return "Usuario no encontrado."
+        if exc.status_code == 409:
+            return "Ya existe otro usuario con ese email."
         return exc.message

--- a/desktop/src/services/api_client.py
+++ b/desktop/src/services/api_client.py
@@ -95,6 +95,14 @@ class ApiClient:
         """Crea un usuario real en el backend FastAPI."""
         return self._request_json("POST", "/api/v1/users/", json=payload)
 
+    def update_user(self, user_id: int, payload: dict) -> dict:
+        """Actualiza datos básicos de un usuario real en el backend."""
+        return self._request_json(
+            "PATCH",
+            f"/api/v1/users/{user_id}",
+            json=payload,
+        )
+
     def update_emergency_status(self, emergency_id: int, payload: dict) -> dict:
         """Actualiza el estado de una emergencia real en el backend."""
         return self._request_json(

--- a/desktop/src/views/user_form_view.py
+++ b/desktop/src/views/user_form_view.py
@@ -28,6 +28,8 @@ class UserFormView(QWidget):
     def __init__(self, controller: UserController | None = None) -> None:
         super().__init__()
         self._controller = controller or UserController()
+        self._usuarios: list[dict] = []
+        self._usuario_editando_id: int | None = None
         self._build_ui()
 
     def _build_ui(self) -> None:
@@ -186,6 +188,7 @@ class UserFormView(QWidget):
         self.tabla_usuarios.setSelectionMode(QTableWidget.SingleSelection)
         self.tabla_usuarios.setEditTriggers(QTableWidget.NoEditTriggers)
         self.tabla_usuarios.setAlternatingRowColors(False)
+        self.tabla_usuarios.itemSelectionChanged.connect(self._on_usuario_seleccionado)
         header = self.tabla_usuarios.horizontalHeader()
         header.setSectionResizeMode(0, QHeaderView.ResizeToContents)
         header.setSectionResizeMode(1, QHeaderView.ResizeToContents)
@@ -195,6 +198,86 @@ class UserFormView(QWidget):
         self.tabla_usuarios.setMinimumHeight(240)
         table_card_lay.addWidget(self.tabla_usuarios)
         outer.addWidget(table_card)
+
+        edit_card = QFrame()
+        edit_card.setObjectName("card")
+        edit_lay = QVBoxLayout(edit_card)
+        edit_lay.setContentsMargins(24, 22, 24, 24)
+        edit_lay.setSpacing(14)
+
+        edit_title = QLabel("Editar usuario seleccionado")
+        edit_title.setObjectName("h1")
+        edit_lay.addWidget(edit_title)
+
+        self.lbl_estado_edicion = QLabel(
+            "Selecciona un usuario del listado para editar sus datos."
+        )
+        self.lbl_estado_edicion.setWordWrap(True)
+        self.lbl_estado_edicion.setStyleSheet("color: #52616B; font-size: 12px;")
+        edit_lay.addWidget(self.lbl_estado_edicion)
+
+        referencia = QHBoxLayout()
+        referencia.setSpacing(20)
+        col_id = QVBoxLayout()
+        col_id.setSpacing(6)
+        col_id.addWidget(self._lbl("ID"))
+        self.lbl_edit_id = QLabel("—")
+        self.lbl_edit_id.setStyleSheet("color: #102A43; font-size: 13px;")
+        col_id.addWidget(self.lbl_edit_id)
+        referencia.addLayout(col_id, 1)
+
+        col_rut = QVBoxLayout()
+        col_rut.setSpacing(6)
+        col_rut.addWidget(self._lbl("RUT"))
+        self.lbl_edit_rut = QLabel("—")
+        self.lbl_edit_rut.setStyleSheet("color: #102A43; font-size: 13px;")
+        col_rut.addWidget(self.lbl_edit_rut)
+        referencia.addLayout(col_rut, 3)
+        edit_lay.addLayout(referencia)
+
+        campo_edit_nombre = QVBoxLayout()
+        campo_edit_nombre.setSpacing(8)
+        campo_edit_nombre.addWidget(self._lbl("Nombre completo *"))
+        self.input_edit_nombre = QLineEdit()
+        self.input_edit_nombre.setMinimumHeight(36)
+        self.input_edit_nombre.setPlaceholderText("Nombre completo")
+        campo_edit_nombre.addWidget(self.input_edit_nombre)
+        edit_lay.addLayout(campo_edit_nombre)
+
+        campo_edit_email = QVBoxLayout()
+        campo_edit_email.setSpacing(8)
+        campo_edit_email.addWidget(self._lbl("Email *"))
+        self.input_edit_email = QLineEdit()
+        self.input_edit_email.setMinimumHeight(36)
+        self.input_edit_email.setPlaceholderText("correo@vecinoseguro.cl")
+        campo_edit_email.addWidget(self.input_edit_email)
+        edit_lay.addLayout(campo_edit_email)
+
+        campo_edit_rol = QVBoxLayout()
+        campo_edit_rol.setSpacing(8)
+        campo_edit_rol.addWidget(self._lbl("Rol *"))
+        self.cb_edit_rol = QComboBox()
+        self.cb_edit_rol.addItem("Vecino", 2)
+        self.cb_edit_rol.addItem("Administrador", 1)
+        self.cb_edit_rol.setMinimumHeight(36)
+        campo_edit_rol.addWidget(self.cb_edit_rol)
+        edit_lay.addLayout(campo_edit_rol)
+
+        edit_buttons = QHBoxLayout()
+        edit_buttons.addStretch()
+        self.btn_cancelar_edicion = QPushButton("Cancelar edición")
+        estilizar_boton(self.btn_cancelar_edicion, "secondary")
+        self.btn_cancelar_edicion.clicked.connect(self._cancelar_edicion)
+        edit_buttons.addWidget(self.btn_cancelar_edicion)
+
+        self.btn_guardar_edicion = QPushButton("Guardar cambios")
+        estilizar_boton(self.btn_guardar_edicion, "primary")
+        self.btn_guardar_edicion.clicked.connect(self._guardar_edicion)
+        edit_buttons.addWidget(self.btn_guardar_edicion)
+        edit_lay.addLayout(edit_buttons)
+
+        outer.addWidget(edit_card)
+        self._set_edicion_habilitada(False)
         outer.addStretch()
 
         scroll.setWidget(content)
@@ -212,14 +295,21 @@ class UserFormView(QWidget):
         self.input_password.clear()
         self.cb_rol.setCurrentIndex(0)
 
-    def refrescar(self) -> None:
+    def refrescar(self, seleccionar_usuario_id: int | None = None) -> None:
         self.btn_refrescar.setEnabled(False)
         self.lbl_estado_listado.setText("Cargando usuarios registrados...")
+        usuario_a_seleccionar = (
+            seleccionar_usuario_id
+            if seleccionar_usuario_id is not None
+            else self._usuario_editando_id
+        )
         try:
             ok, msg, usuarios = self._controller.listar_usuarios()
             if not ok:
+                self._usuarios = []
                 self.tabla_usuarios.setRowCount(0)
                 self.lbl_estado_listado.setText(msg)
+                self._limpiar_edicion()
                 return
 
             self._cargar_tabla(usuarios)
@@ -227,12 +317,18 @@ class UserFormView(QWidget):
                 self.lbl_estado_listado.setText(
                     f"{len(usuarios)} usuario(s) registrado(s)."
                 )
+                if usuario_a_seleccionar is not None:
+                    if not self._seleccionar_usuario_por_id(usuario_a_seleccionar):
+                        self._limpiar_edicion()
             else:
                 self.lbl_estado_listado.setText("No hay usuarios registrados.")
+                self._limpiar_edicion()
         finally:
             self.btn_refrescar.setEnabled(True)
 
     def _cargar_tabla(self, usuarios: list[dict]) -> None:
+        self._usuarios = usuarios
+        senales_bloqueadas = self.tabla_usuarios.blockSignals(True)
         self.tabla_usuarios.setRowCount(len(usuarios))
         for row, usuario in enumerate(usuarios):
             self._set_cell(
@@ -242,6 +338,7 @@ class UserFormView(QWidget):
                 align=Qt.AlignCenter,
                 color="#52616B",
                 weight=600,
+                data=usuario,
             )
             self._set_cell(row, 1, str(usuario.get("rut", "")))
             self._set_cell(row, 2, str(usuario.get("full_name", "")))
@@ -254,6 +351,7 @@ class UserFormView(QWidget):
                 weight=600,
             )
             self.tabla_usuarios.setRowHeight(row, 38)
+        self.tabla_usuarios.blockSignals(senales_bloqueadas)
 
     def _set_cell(
         self,
@@ -263,6 +361,7 @@ class UserFormView(QWidget):
         align=Qt.AlignLeft | Qt.AlignVCenter,
         color: str | None = None,
         weight: int = 400,
+        data: object | None = None,
     ) -> None:
         item = QTableWidgetItem(texto)
         item.setTextAlignment(align)
@@ -276,6 +375,8 @@ class UserFormView(QWidget):
         else:
             font.setWeight(QFont.Weight.Normal)
         item.setFont(font)
+        if data is not None:
+            item.setData(Qt.UserRole, data)
         self.tabla_usuarios.setItem(row, col, item)
 
     def _nombre_rol(self, role: object) -> str:
@@ -285,6 +386,123 @@ class UserFormView(QWidget):
         if texto.lower() == "vecino":
             return "Vecino"
         return texto
+
+    def _on_usuario_seleccionado(self) -> None:
+        rows = self.tabla_usuarios.selectionModel().selectedRows()
+        if not rows:
+            self._limpiar_edicion()
+            return
+
+        usuario = self._usuario_desde_fila(rows[0].row())
+        if usuario is None:
+            self._limpiar_edicion()
+            return
+        self._cargar_edicion(usuario)
+
+    def _usuario_desde_fila(self, row: int) -> dict | None:
+        item = self.tabla_usuarios.item(row, 0)
+        if item is None:
+            return None
+        usuario = item.data(Qt.UserRole)
+        return usuario if isinstance(usuario, dict) else None
+
+    def _cargar_edicion(self, usuario: dict) -> None:
+        user_id = self._int_or_none(usuario.get("id"))
+        if user_id is None:
+            self._limpiar_edicion()
+            return
+
+        self._usuario_editando_id = user_id
+        self.lbl_edit_id.setText(str(user_id))
+        self.lbl_edit_rut.setText(str(usuario.get("rut", "")))
+        self.input_edit_nombre.setText(str(usuario.get("full_name", "")))
+        self.input_edit_email.setText(str(usuario.get("email", "")))
+
+        role_id = self._int_or_none(usuario.get("role_id")) or 2
+        idx = self.cb_edit_rol.findData(role_id)
+        self.cb_edit_rol.setCurrentIndex(idx if idx >= 0 else 0)
+
+        self.lbl_estado_edicion.setText(
+            "Puedes editar nombre completo, email y rol. El ID y RUT son solo referencia."
+        )
+        self._set_edicion_habilitada(True)
+
+    def _limpiar_edicion(self) -> None:
+        self._usuario_editando_id = None
+        self.lbl_edit_id.setText("—")
+        self.lbl_edit_rut.setText("—")
+        self.input_edit_nombre.clear()
+        self.input_edit_email.clear()
+        self.cb_edit_rol.setCurrentIndex(0)
+        self.lbl_estado_edicion.setText(
+            "Selecciona un usuario del listado para editar sus datos."
+        )
+        self._set_edicion_habilitada(False)
+
+    def _set_edicion_habilitada(self, habilitada: bool) -> None:
+        self.input_edit_nombre.setEnabled(habilitada)
+        self.input_edit_email.setEnabled(habilitada)
+        self.cb_edit_rol.setEnabled(habilitada)
+        self.btn_guardar_edicion.setEnabled(habilitada)
+        self.btn_cancelar_edicion.setEnabled(habilitada)
+
+    def _cancelar_edicion(self) -> None:
+        senales_bloqueadas = self.tabla_usuarios.blockSignals(True)
+        self.tabla_usuarios.clearSelection()
+        self.tabla_usuarios.blockSignals(senales_bloqueadas)
+        self._limpiar_edicion()
+
+    def _guardar_edicion(self) -> None:
+        if self._usuario_editando_id is None:
+            QMessageBox.warning(
+                self,
+                "Sin usuario seleccionado",
+                "Selecciona un usuario del listado antes de guardar cambios.",
+            )
+            return
+
+        user_id = self._usuario_editando_id
+        self.btn_guardar_edicion.setEnabled(False)
+        self.btn_guardar_edicion.setText("Guardando...")
+        try:
+            ok, msg, actualizado = self._controller.editar_usuario(
+                user_id=user_id,
+                full_name=self.input_edit_nombre.text(),
+                email=self.input_edit_email.text(),
+                role_id=int(self.cb_edit_rol.currentData()),
+            )
+            if not ok:
+                QMessageBox.warning(self, "No fue posible editar el usuario", msg)
+                return
+
+            nombre = (
+                actualizado.get("full_name", self.input_edit_nombre.text().strip())
+                if actualizado
+                else self.input_edit_nombre.text().strip()
+            )
+            QMessageBox.information(
+                self,
+                "Usuario actualizado",
+                f"Usuario actualizado correctamente.\n\nNombre: {nombre}",
+            )
+            self.refrescar(seleccionar_usuario_id=user_id)
+        finally:
+            self.btn_guardar_edicion.setText("Guardar cambios")
+            self.btn_guardar_edicion.setEnabled(self._usuario_editando_id is not None)
+
+    def _seleccionar_usuario_por_id(self, user_id: int) -> bool:
+        for row in range(self.tabla_usuarios.rowCount()):
+            usuario = self._usuario_desde_fila(row)
+            if usuario and self._int_or_none(usuario.get("id")) == user_id:
+                self.tabla_usuarios.selectRow(row)
+                return True
+        return False
+
+    def _int_or_none(self, value: object) -> int | None:
+        try:
+            return int(value)
+        except (TypeError, ValueError):
+            return None
 
     def _guardar(self) -> None:
         self.btn_guardar.setEnabled(False)


### PR DESCRIPTION
## Resumen

Este PR agrega la edición básica de usuarios desde el panel administrador desktop.

Ahora los administradores pueden seleccionar un usuario desde la tabla de usuarios registrados y editar sus datos básicos: nombre completo, email y rol.

## Cambios principales

- Se agregó `PATCH /api/v1/users/{user_id}` en backend.
- Se permite editar:
  - nombre completo;
  - email;
  - rol.
- No se permite editar RUT.
- No se permite editar contraseña.
- La respuesta no expone `password` ni `password_hash`.
- Se valida usuario inexistente con `404`.
- Se valida email duplicado contra otro usuario con `409`.
- Se valida nombre obligatorio, email válido y rol permitido.
- Se agregó `ApiClient.update_user(...)`.
- Se agregó `UserController.editar_usuario(...)`.
- En la vista **Usuarios**, se agregó la sección **Editar usuario seleccionado**.
- Al seleccionar un usuario en la tabla, se cargan sus datos editables.
- ID y RUT quedan solo como referencia.
- Al guardar cambios, se refresca la tabla y se mantiene seleccionado el usuario editado.
- Se agregó botón **Cancelar edición**.
- Se actualizaron los README de backend y desktop.

## Pruebas realizadas

- [x] `backend\.venv\Scripts\python.exe -m compileall backend\app`
- [x] `desktop\.venv\Scripts\python.exe -m compileall desktop\src`
- [x] `git diff --check`
- [x] Probado `PATCH /api/v1/users/{user_id}` desde Swagger con datos válidos.
- [x] Confirmada respuesta `200 OK`.
- [x] Confirmado que la respuesta no incluye `password` ni `password_hash`.
- [x] Probado usuario inexistente con respuesta `404`.
- [x] Probado email duplicado con respuesta `409`.
- [x] Probado rol inválido con respuesta `400`.
- [x] Probado nombre vacío con respuesta `400`.
- [x] Probada edición desde desktop con usuario administrador.
- [x] Verificado que la tabla se refresca después de guardar.
- [x] Verificado que creación de usuario sigue funcionando.
- [x] Verificado que usuario vecino no ve el acceso a Usuarios.

## Alcance

Este PR implementa solo edición básica de usuarios desde desktop/admin.

## No se modificó

- Mobile
- Database
- Login
- Reportes
- Emergencias
- Eliminación de usuarios
- Cambio/restablecimiento de contraseña
- Edición de RUT

## Limitación conocida

El endpoint `PATCH /api/v1/users/{user_id}` aún no exige token ni autorización backend. En esta etapa, el acceso se restringe desde la app desktop mostrando la vista **Usuarios** solo a administradores.