### PR TITLE
feat: allow admins to deactivate users

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -81,7 +81,22 @@ Pasos:
 
 Los datos cargados desde `seed.sql` permiten probar login, emergencias y reportes locales.
 
-No modificar `database/schema.sql` ni `database/seed.sql` desde tareas de documentación.
+## Actualización de bases locales existentes
+
+Si la base local ya fue creada antes de agregar estados activo/inactivo de
+usuarios, ejecutar manualmente:
+
+```sql
+ALTER TABLE users
+ADD COLUMN is_active TINYINT(1) NOT NULL DEFAULT 1
+COMMENT 'Indica si el usuario puede iniciar sesión'
+AFTER role_id;
+
+CREATE INDEX idx_users_is_active ON users(is_active);
+```
+
+Si se reconstruye la base desde cero, basta con ejecutar `database/schema.sql`
+y luego `database/seed.sql` actualizados.
 
 ---
 
@@ -151,6 +166,7 @@ POST /api/v1/auth/login
 GET /api/v1/users/
 POST /api/v1/users/
 PATCH /api/v1/users/{user_id}
+PATCH /api/v1/users/{user_id}/active
 GET /api/v1/emergencies/
 GET /api/v1/emergencies/summary
 GET /api/v1/emergencies/recent?limit=4
@@ -251,8 +267,9 @@ Body de prueba para vecino:
 
 # Gestión básica de usuarios
 
-El módulo `users` permite listar, crear y editar usuarios reales desde el panel
-administrador desktop.
+El módulo `users` permite listar, crear, editar y activar/desactivar usuarios
+reales desde el panel administrador desktop. Los usuarios inactivos se conservan
+en la base de datos, pero no pueden iniciar sesión.
 
 ## Listar usuarios
 
@@ -275,7 +292,8 @@ Ejemplo:
     "full_name": "Administradora Vecinal",
     "email": "admin@vecinoseguro.cl",
     "role_id": 1,
-    "role": "admin"
+    "role": "admin",
+    "is_active": true
   },
   {
     "id": 2,
@@ -283,7 +301,8 @@ Ejemplo:
     "full_name": "Carlos Pérez Soto",
     "email": "carlos.perez@vecinoseguro.cl",
     "role_id": 2,
-    "role": "vecino"
+    "role": "vecino",
+    "is_active": true
   }
 ]
 ```
@@ -331,7 +350,8 @@ Respuesta segura:
   "rut": "12345678-5",
   "full_name": "Nuevo Vecino",
   "email": "nuevo.vecino@vecinoseguro.cl",
-  "role_id": 2
+  "role_id": 2,
+  "is_active": true
 }
 ```
 
@@ -386,7 +406,8 @@ Respuesta segura:
   "full_name": "Nombre Actualizado",
   "email": "correo.actualizado@vecinoseguro.cl",
   "role_id": 2,
-  "role": "vecino"
+  "role": "vecino",
+  "is_active": true
 }
 ```
 
@@ -402,6 +423,59 @@ Limitación temporal: este endpoint aún no exige token ni permisos backend. Por
 ahora el acceso se restringe desde la app desktop mostrando la vista solo a
 usuarios con rol administrador. La autorización backend avanzada queda para una
 etapa posterior.
+
+## Activar o desactivar usuarios
+
+Endpoint:
+
+```text
+PATCH /api/v1/users/{user_id}/active
+```
+
+Permite marcar un usuario como activo o inactivo sin eliminarlo. Un usuario
+inactivo conserva su RUT, datos, rol y relaciones históricas con reportes, pero
+no puede iniciar sesión.
+
+Body para desactivar:
+
+```json
+{
+  "is_active": false
+}
+```
+
+Body para activar:
+
+```json
+{
+  "is_active": true
+}
+```
+
+Respuesta segura:
+
+```json
+{
+  "id": 4,
+  "rut": "12345678-5",
+  "full_name": "Usuario Prueba",
+  "email": "usuario.prueba@vecinoseguro.cl",
+  "role_id": 2,
+  "role": "vecino",
+  "is_active": false
+}
+```
+
+Respuestas esperadas:
+
+* `200 OK`: estado actualizado.
+* `400 Bad Request`: ID inválido o intento de desactivar el último administrador activo.
+* `404 Not Found`: usuario inexistente.
+* `500 Internal Server Error`: error no controlado.
+
+El backend impide dejar el sistema sin administradores activos. La restricción
+de no desactivar la cuenta propia se aplica desde desktop mientras no exista
+autorización backend con token.
 
 ---
 
@@ -699,13 +773,16 @@ Ejemplo de respuesta:
 9. Probar `PATCH /api/v1/users/{user_id}` con nombre, email y rol válidos.
 10. Probar errores de usuario inexistente, email duplicado y rol inválido.
 11. Confirmar que la respuesta de edición no incluya `password_hash`.
-12. Probar `GET /api/v1/emergencies/`.
-13. Probar `GET /api/v1/emergencies/summary`.
-14. Probar `GET /api/v1/emergencies/recent?limit=4`.
-15. Probar `GET /api/v1/emergencies/catalogs`.
-16. Probar `GET /api/v1/reports/summary`.
-17. Probar `GET /api/v1/reports/dashboard-cards`.
-18. Verificar que las respuestas sean coherentes con los datos cargados desde `database/seed.sql`.
+12. Probar `PATCH /api/v1/users/{user_id}/active` para desactivar y activar usuarios.
+13. Confirmar que un usuario inactivo no puede iniciar sesión.
+14. Confirmar que no se puede desactivar el último administrador activo.
+15. Probar `GET /api/v1/emergencies/`.
+16. Probar `GET /api/v1/emergencies/summary`.
+17. Probar `GET /api/v1/emergencies/recent?limit=4`.
+18. Probar `GET /api/v1/emergencies/catalogs`.
+19. Probar `GET /api/v1/reports/summary`.
+20. Probar `GET /api/v1/reports/dashboard-cards`.
+21. Verificar que las respuestas sean coherentes con los datos cargados desde `database/seed.sql`.
 
 ---
 

--- a/backend/app/modules/auth/service.py
+++ b/backend/app/modules/auth/service.py
@@ -39,6 +39,9 @@ class AuthService:
         if user is None:
             raise InvalidCredentialsError
 
+        if not bool(user.get("is_active", True)):
+            raise InvalidCredentialsError
+
         password_hash = user.get("password_hash")
         if not password_hash:
             raise InvalidCredentialsError

--- a/backend/app/modules/users/repository.py
+++ b/backend/app/modules/users/repository.py
@@ -22,7 +22,8 @@ class UserRepository:
                 u.full_name,
                 u.email,
                 u.role_id,
-                r.name AS role
+                r.name AS role,
+                u.is_active
             FROM users u
             INNER JOIN roles r ON r.id = u.role_id
             ORDER BY u.id ASC
@@ -50,7 +51,8 @@ class UserRepository:
                 full_name,
                 email,
                 password_hash,
-                role_id
+                role_id,
+                is_active
             FROM users
             WHERE rut = %s
             LIMIT 1
@@ -77,7 +79,8 @@ class UserRepository:
                 full_name,
                 email,
                 password_hash,
-                role_id
+                role_id,
+                is_active
             FROM users
             WHERE email = %s
             LIMIT 1
@@ -103,7 +106,8 @@ class UserRepository:
                 rut,
                 full_name,
                 email,
-                role_id
+                role_id,
+                is_active
             FROM users
             WHERE id = %s
             LIMIT 1
@@ -133,7 +137,8 @@ class UserRepository:
                 rut,
                 full_name,
                 email,
-                role_id
+                role_id,
+                is_active
             FROM users
             WHERE email = %s
               AND id <> %s
@@ -168,6 +173,28 @@ class UserRepository:
             if connection is not None:
                 connection.close()
 
+    def count_active_admins(self) -> int:
+        """Cuenta administradores activos para proteger acceso al sistema."""
+        query = """
+            SELECT COUNT(*) AS total
+            FROM users
+            WHERE role_id = 1
+              AND is_active = 1
+        """
+        connection = None
+        cursor = None
+        try:
+            connection = get_connection()
+            cursor = connection.cursor(dictionary=True)
+            cursor.execute(query)
+            row = cursor.fetchone()
+            return int(row["total"]) if row else 0
+        finally:
+            if cursor is not None:
+                cursor.close()
+            if connection is not None:
+                connection.close()
+
     def create_user(
         self,
         rut: str,
@@ -193,7 +220,8 @@ class UserRepository:
                 rut,
                 full_name,
                 email,
-                role_id
+                role_id,
+                is_active
             FROM users
             WHERE id = %s
             LIMIT 1
@@ -215,6 +243,54 @@ class UserRepository:
                 raise RuntimeError("No fue posible recuperar el usuario creado")
 
             return UserCreateResponse(**row)
+        except Exception:
+            try:
+                connection.rollback()
+            except Exception:
+                pass
+            raise
+        finally:
+            if cursor is not None:
+                cursor.close()
+            connection.close()
+
+    def update_active_status(
+        self,
+        user_id: int,
+        is_active: bool,
+    ) -> UserListItem | None:
+        """Actualiza el estado activo/inactivo y retorna el usuario seguro."""
+        update_query = """
+            UPDATE users
+            SET is_active = %s
+            WHERE id = %s
+        """
+        select_query = """
+            SELECT
+                u.id,
+                u.rut,
+                u.full_name,
+                u.email,
+                u.role_id,
+                r.name AS role,
+                u.is_active
+            FROM users u
+            INNER JOIN roles r ON r.id = u.role_id
+            WHERE u.id = %s
+            LIMIT 1
+        """
+        connection = get_connection()
+        cursor = None
+        try:
+            cursor = connection.cursor(dictionary=True)
+            cursor.execute(update_query, (1 if is_active else 0, user_id))
+            connection.commit()
+
+            cursor.execute(select_query, (user_id,))
+            row = cursor.fetchone()
+            if row is None:
+                return None
+            return UserListItem(**row)
         except Exception:
             try:
                 connection.rollback()
@@ -248,7 +324,8 @@ class UserRepository:
                 u.full_name,
                 u.email,
                 u.role_id,
-                r.name AS role
+                r.name AS role,
+                u.is_active
             FROM users u
             INNER JOIN roles r ON r.id = u.role_id
             WHERE u.id = %s

--- a/backend/app/modules/users/router.py
+++ b/backend/app/modules/users/router.py
@@ -3,6 +3,7 @@
 from fastapi import APIRouter, HTTPException, status
 
 from app.modules.users.schemas import (
+    UserActiveUpdateRequest,
     UserCreateRequest,
     UserCreateResponse,
     UserListItem,
@@ -12,6 +13,7 @@ from app.modules.users.service import (
     InvalidRoleError,
     InvalidUserDataError,
     UserAlreadyExistsError,
+    UserActivationError,
     UserNotFoundError,
     UserService,
 )
@@ -41,7 +43,7 @@ def create_user(user_data: UserCreateRequest) -> UserCreateResponse:
     """Crea un usuario real en MySQL/MariaDB sin exponer contraseña."""
     try:
         return user_service.create_user(user_data)
-    except (InvalidUserDataError, InvalidRoleError) as exc:
+    except (InvalidUserDataError, InvalidRoleError, UserActivationError) as exc:
         raise HTTPException(status_code=400, detail=str(exc)) from exc
     except UserAlreadyExistsError as exc:
         raise HTTPException(status_code=409, detail=str(exc)) from exc
@@ -67,4 +69,23 @@ def update_user(user_id: int, user_data: UserUpdateRequest) -> UserListItem:
         raise HTTPException(
             status_code=500,
             detail="No fue posible actualizar el usuario",
+        ) from exc
+
+
+@router.patch("/{user_id}/active", response_model=UserListItem)
+def update_user_active_status(
+    user_id: int,
+    user_data: UserActiveUpdateRequest,
+) -> UserListItem:
+    """Activa o desactiva un usuario sin eliminarlo."""
+    try:
+        return user_service.update_active_status(user_id, user_data)
+    except (InvalidUserDataError, UserActivationError) as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    except UserNotFoundError as exc:
+        raise HTTPException(status_code=404, detail=str(exc)) from exc
+    except Exception as exc:
+        raise HTTPException(
+            status_code=500,
+            detail="No fue posible cambiar el estado del usuario",
         ) from exc

--- a/backend/app/modules/users/schemas.py
+++ b/backend/app/modules/users/schemas.py
@@ -21,6 +21,7 @@ class UserListItem(BaseModel):
     email: str
     role_id: int
     role: str
+    is_active: bool
 
 
 class UserCreateRequest(BaseModel):
@@ -41,6 +42,12 @@ class UserUpdateRequest(BaseModel):
     role_id: int
 
 
+class UserActiveUpdateRequest(BaseModel):
+    """Estado activo/inactivo de un usuario."""
+
+    is_active: bool
+
+
 class UserCreateResponse(BaseModel):
     """Respuesta segura para altas de usuario, sin contraseña ni hash."""
 
@@ -49,3 +56,4 @@ class UserCreateResponse(BaseModel):
     full_name: str
     email: str
     role_id: int
+    is_active: bool = True

--- a/backend/app/modules/users/service.py
+++ b/backend/app/modules/users/service.py
@@ -5,6 +5,7 @@ from passlib.context import CryptContext
 
 from app.modules.users.repository import UserRepository
 from app.modules.users.schemas import (
+    UserActiveUpdateRequest,
     UserCreateRequest,
     UserCreateResponse,
     UserListItem,
@@ -31,6 +32,10 @@ class InvalidRoleError(ValueError):
 
 class UserNotFoundError(LookupError):
     """Indica que el usuario solicitado no existe."""
+
+
+class UserActivationError(ValueError):
+    """Indica que no se puede cambiar el estado activo del usuario."""
 
 
 class UserService:
@@ -115,10 +120,21 @@ class UserService:
         if not self.repository.role_exists(role_id):
             raise InvalidRoleError("El rol indicado no existe")
 
-        if self.repository.find_by_id(user_id) is None:
+        existing_user = self.repository.find_by_id(user_id)
+        if existing_user is None:
             raise UserNotFoundError("Usuario no encontrado")
         if self.repository.find_by_email_excluding_user(email, user_id) is not None:
             raise UserAlreadyExistsError("Ya existe otro usuario con ese email")
+
+        if (
+            int(existing_user["role_id"]) == 1
+            and bool(existing_user.get("is_active", True))
+            and role_id != 1
+            and self.repository.count_active_admins() <= 1
+        ):
+            raise UserActivationError(
+                "No es posible quitar el rol al último administrador activo"
+            )
 
         try:
             updated = self.repository.update_user(
@@ -134,6 +150,35 @@ class UserService:
                 ) from exc
             raise
 
+        if updated is None:
+            raise UserNotFoundError("Usuario no encontrado")
+        return updated
+
+    def update_active_status(
+        self,
+        user_id: int,
+        request: UserActiveUpdateRequest,
+    ) -> UserListItem:
+        """Activa o desactiva un usuario sin eliminarlo de la base."""
+        if user_id <= 0:
+            raise InvalidUserDataError("ID de usuario inválido")
+
+        user = self.repository.find_by_id(user_id)
+        if user is None:
+            raise UserNotFoundError("Usuario no encontrado")
+
+        next_is_active = bool(request.is_active)
+        is_admin = int(user["role_id"]) == 1
+        is_currently_active = bool(user.get("is_active", True))
+
+        if is_admin and is_currently_active and not next_is_active:
+            active_admins = self.repository.count_active_admins()
+            if active_admins <= 1:
+                raise UserActivationError(
+                    "No es posible desactivar el último administrador activo"
+                )
+
+        updated = self.repository.update_active_status(user_id, next_is_active)
         if updated is None:
             raise UserNotFoundError("Usuario no encontrado")
         return updated

--- a/database/schema.sql
+++ b/database/schema.sql
@@ -42,6 +42,7 @@ CREATE TABLE IF NOT EXISTS users (
   email         VARCHAR(150) NOT NULL UNIQUE COMMENT 'Correo electrónico único',
   password_hash VARCHAR(255) NOT NULL        COMMENT 'Hash seguro de la contraseña (bcrypt/argon2)',
   role_id       INT          NOT NULL        COMMENT 'Rol asignado al usuario',
+  is_active     TINYINT(1)   NOT NULL DEFAULT 1 COMMENT 'Indica si el usuario puede iniciar sesión',
   created_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP,
   updated_at    TIMESTAMP    NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
   CONSTRAINT fk_users_roles
@@ -103,6 +104,7 @@ CREATE TABLE IF NOT EXISTS emergency_status_history (
 --    ordenar por fecha de creación o auditar cambios por usuario.
 -- -----------------------------------------------------------------------------
 CREATE INDEX idx_users_role_id              ON users(role_id);
+CREATE INDEX idx_users_is_active            ON users(is_active);
 CREATE INDEX idx_emergencies_user_id        ON emergencies(user_id);
 CREATE INDEX idx_emergencies_status         ON emergencies(status);
 CREATE INDEX idx_emergencies_urgency_level  ON emergencies(urgency_level);

--- a/database/seed.sql
+++ b/database/seed.sql
@@ -28,26 +28,30 @@ ON DUPLICATE KEY UPDATE description = VALUES(description);
 --      maria.gonzalez@vecinoseguro.cl -> vecino1234
 --    password_hash contiene hashes bcrypt válidos. NO usar en producción.
 -- -----------------------------------------------------------------------------
-INSERT INTO users (rut, full_name, email, password_hash, role_id)
+INSERT INTO users (rut, full_name, email, password_hash, role_id, is_active)
 VALUES
   ('11111111-1',
    'Administradora Vecinal',
    'admin@vecinoseguro.cl',
    '$2b$12$abcdefghijklmnopqrstuuQGuv7JMXhF88lMrtF64dVMmrFWSg9Hy',
+   1,
    1),
   ('22222222-2',
    'Carlos Pérez Soto',
    'carlos.perez@vecinoseguro.cl',
    '$2b$12$abcdefghijklmnopqrstuut5sNDb4knLOg6.NM2MEDpS74Bo24SPG',
-   2),
+   2,
+   1),
   ('13456789-9',
    'María González Rojas',
    'maria.gonzalez@vecinoseguro.cl',
    '$2b$12$abcdefghijklmnopqrstuut5sNDb4knLOg6.NM2MEDpS74Bo24SPG',
-   2)
+   2,
+   1)
 ON DUPLICATE KEY UPDATE
   full_name = VALUES(full_name),
-  password_hash = VALUES(password_hash);
+  password_hash = VALUES(password_hash),
+  is_active = VALUES(is_active);
 
 -- -----------------------------------------------------------------------------
 -- 3. Emergencias de ejemplo

--- a/desktop/README.md
+++ b/desktop/README.md
@@ -59,8 +59,8 @@ datos reales del entorno local.
 - **Detalle del reporte** con cambio de estado y eliminación con confirmación
   disponibles solo para administradores.
 - **Gestión básica de usuarios** visible solo para administradores, con
-  creación de cuentas, listado de usuarios registrados y edición de nombre,
-  email y rol.
+  creación de cuentas, listado de usuarios registrados, edición de nombre,
+  email y rol, y activación/desactivación sin eliminar registros.
 
 ## Integración con backend
 
@@ -110,6 +110,8 @@ FastAPI` y consume:
   contraseña inicial y rol.
 - `PATCH /api/v1/users/{user_id}` para editar nombre, email y rol de usuarios
   existentes.
+- `PATCH /api/v1/users/{user_id}/active` para activar o desactivar usuarios
+  sin eliminarlos.
 
 El desktop no envía `status`; el backend asigna el estado inicial
 `pendiente`.
@@ -130,12 +132,14 @@ rol `role_id=1` se interpreta como administrador y `role_id=2` como vecino.
 Los administradores ven el acceso lateral **Usuarios** y pueden crear cuentas
 con rol **Vecino** (`role_id=2`) o **Administrador** (`role_id=1`). En la misma
 vista pueden consultar una tabla de usuarios registrados con ID, RUT, nombre,
-email y rol; después de crear un usuario, el listado se actualiza para mostrar
-el nuevo registro. Al seleccionar una fila, pueden editar nombre completo,
-email y rol desde una sección separada. No se edita RUT, no se cambia
-contraseña y no se eliminan usuarios desde esta vista. Los vecinos no ven ese
-acceso en la navegación normal. La contraseña inicial no se muestra ni se guarda
-en desktop; el backend la persiste como hash bcrypt.
+email, rol y estado Activo/Inactivo; después de crear un usuario, el listado se
+actualiza para mostrar el nuevo registro. Al seleccionar una fila, pueden editar
+nombre completo, email y rol desde una sección separada, y activar o desactivar
+el usuario con confirmación. No se edita RUT, no se cambia contraseña y no se
+eliminan usuarios desde esta vista. Desactivar conserva reportes asociados e
+historial, pero impide el inicio de sesión. Los vecinos no ven ese acceso en la
+navegación normal. La contraseña inicial no se muestra ni se guarda en desktop;
+el backend la persiste como hash bcrypt.
 
 Respuesta segura esperada desde `GET /api/v1/users/`:
 
@@ -147,7 +151,8 @@ Respuesta segura esperada desde `GET /api/v1/users/`:
     "full_name": "Administradora Vecinal",
     "email": "admin@vecinoseguro.cl",
     "role_id": 1,
-    "role": "admin"
+    "role": "admin",
+    "is_active": true
   }
 ]
 ```
@@ -163,11 +168,29 @@ Respuesta segura esperada desde `PATCH /api/v1/users/{user_id}`:
   "full_name": "Usuario Editado",
   "email": "usuario.editado@vecinoseguro.cl",
   "role_id": 2,
-  "role": "vecino"
+  "role": "vecino",
+  "is_active": true
 }
 ```
 
 La edición básica no expone contraseñas ni hashes.
+
+Respuesta segura esperada desde `PATCH /api/v1/users/{user_id}/active`:
+
+```json
+{
+  "id": 4,
+  "rut": "12345678-5",
+  "full_name": "Nuevo Vecino",
+  "email": "nuevo.vecino@vecinoseguro.cl",
+  "role_id": 2,
+  "role": "vecino",
+  "is_active": false
+}
+```
+
+El desktop bloquea la autodesactivación del administrador que está usando la
+sesión. El backend, además, impide dejar el sistema sin administradores activos.
 
 Respuesta segura esperada desde `POST /api/v1/users/`:
 
@@ -177,7 +200,8 @@ Respuesta segura esperada desde `POST /api/v1/users/`:
   "rut": "12345678-5",
   "full_name": "Nuevo Vecino",
   "email": "nuevo.vecino@vecinoseguro.cl",
-  "role_id": 2
+  "role_id": 2,
+  "is_active": true
 }
 ```
 

--- a/desktop/src/controllers/user_controller.py
+++ b/desktop/src/controllers/user_controller.py
@@ -96,6 +96,22 @@ class UserController:
         except ApiClientError as exc:
             return False, self._mensaje_edicion_error(exc), None
 
+    def cambiar_estado_usuario(
+        self,
+        user_id: int,
+        is_active: bool,
+    ) -> tuple[bool, str, dict | None]:
+        """Solicita activar o desactivar un usuario existente."""
+        if user_id <= 0:
+            return False, "Debe seleccionar un usuario válido.", None
+
+        try:
+            actualizado = self._api.update_user_active_status(user_id, is_active)
+            estado = "activado" if is_active else "desactivado"
+            return True, f"Usuario {estado} correctamente.", actualizado
+        except ApiClientError as exc:
+            return False, self._mensaje_estado_error(exc), None
+
     def _mensaje_api_error(self, exc: ApiClientError) -> str:
         if isinstance(exc.detail, str) and exc.detail:
             return exc.detail
@@ -110,4 +126,13 @@ class UserController:
             return "Usuario no encontrado."
         if exc.status_code == 409:
             return "Ya existe otro usuario con ese email."
+        return exc.message
+
+    def _mensaje_estado_error(self, exc: ApiClientError) -> str:
+        if isinstance(exc.detail, str) and exc.detail:
+            return exc.detail
+        if exc.status_code == 404:
+            return "Usuario no encontrado."
+        if exc.status_code == 400:
+            return "No fue posible cambiar el estado del usuario."
         return exc.message

--- a/desktop/src/services/api_client.py
+++ b/desktop/src/services/api_client.py
@@ -103,6 +103,14 @@ class ApiClient:
             json=payload,
         )
 
+    def update_user_active_status(self, user_id: int, is_active: bool) -> dict:
+        """Activa o desactiva un usuario real en el backend."""
+        return self._request_json(
+            "PATCH",
+            f"/api/v1/users/{user_id}/active",
+            json={"is_active": is_active},
+        )
+
     def update_emergency_status(self, emergency_id: int, payload: dict) -> dict:
         """Actualiza el estado de una emergencia real en el backend."""
         return self._request_json(

--- a/desktop/src/views/main_window.py
+++ b/desktop/src/views/main_window.py
@@ -254,6 +254,7 @@ class MainWindow(QMainWindow):
         self.dashboard.set_usuario(usuario)
         self.form_view.set_usuario(usuario)
         self.list_view.set_usuario(usuario)
+        self.user_form_view.set_usuario(usuario)
 
         is_admin = usuario.rol == Rol.ADMIN
         self.admin_section.setVisible(is_admin)

--- a/desktop/src/views/user_form_view.py
+++ b/desktop/src/views/user_form_view.py
@@ -19,6 +19,7 @@ from PySide6.QtCore import Qt
 from PySide6.QtGui import QColor, QFont
 
 from src.controllers.user_controller import UserController
+from src.models.entities import Usuario
 from src.widgets.buttons import estilizar_boton
 
 
@@ -30,6 +31,8 @@ class UserFormView(QWidget):
         self._controller = controller or UserController()
         self._usuarios: list[dict] = []
         self._usuario_editando_id: int | None = None
+        self._usuario_editando_activo = True
+        self._usuario_actual: Usuario | None = None
         self._build_ui()
 
     def _build_ui(self) -> None:
@@ -179,9 +182,9 @@ class UserFormView(QWidget):
         table_card_lay.addWidget(self.lbl_estado_listado)
 
         self.tabla_usuarios = QTableWidget()
-        self.tabla_usuarios.setColumnCount(5)
+        self.tabla_usuarios.setColumnCount(6)
         self.tabla_usuarios.setHorizontalHeaderLabels(
-            ["ID", "RUT", "Nombre", "Email", "Rol"]
+            ["ID", "RUT", "Nombre", "Email", "Rol", "Estado"]
         )
         self.tabla_usuarios.verticalHeader().setVisible(False)
         self.tabla_usuarios.setSelectionBehavior(QTableWidget.SelectRows)
@@ -195,6 +198,7 @@ class UserFormView(QWidget):
         header.setSectionResizeMode(2, QHeaderView.Stretch)
         header.setSectionResizeMode(3, QHeaderView.Stretch)
         header.setSectionResizeMode(4, QHeaderView.ResizeToContents)
+        header.setSectionResizeMode(5, QHeaderView.ResizeToContents)
         self.tabla_usuarios.setMinimumHeight(240)
         table_card_lay.addWidget(self.tabla_usuarios)
         outer.addWidget(table_card)
@@ -263,8 +267,22 @@ class UserFormView(QWidget):
         campo_edit_rol.addWidget(self.cb_edit_rol)
         edit_lay.addLayout(campo_edit_rol)
 
+        estado_row = QHBoxLayout()
+        estado_row.setSpacing(10)
+        estado_row.addWidget(self._lbl("Estado actual"))
+        self.lbl_edit_estado = QLabel("—")
+        self.lbl_edit_estado.setStyleSheet("color: #52616B; font-size: 13px;")
+        estado_row.addWidget(self.lbl_edit_estado)
+        estado_row.addStretch()
+        edit_lay.addLayout(estado_row)
+
         edit_buttons = QHBoxLayout()
         edit_buttons.addStretch()
+        self.btn_estado_usuario = QPushButton("Desactivar usuario")
+        estilizar_boton(self.btn_estado_usuario, "danger")
+        self.btn_estado_usuario.clicked.connect(self._cambiar_estado_usuario)
+        edit_buttons.addWidget(self.btn_estado_usuario)
+
         self.btn_cancelar_edicion = QPushButton("Cancelar edición")
         estilizar_boton(self.btn_cancelar_edicion, "secondary")
         self.btn_cancelar_edicion.clicked.connect(self._cancelar_edicion)
@@ -294,6 +312,10 @@ class UserFormView(QWidget):
         self.input_email.clear()
         self.input_password.clear()
         self.cb_rol.setCurrentIndex(0)
+
+    def set_usuario(self, usuario: Usuario) -> None:
+        """Recibe el usuario autenticado para evitar autodesactivación."""
+        self._usuario_actual = usuario
 
     def refrescar(self, seleccionar_usuario_id: int | None = None) -> None:
         self.btn_refrescar.setEnabled(False)
@@ -348,6 +370,15 @@ class UserFormView(QWidget):
                 4,
                 self._nombre_rol(usuario.get("role")),
                 align=Qt.AlignCenter,
+                weight=600,
+            )
+            activo = self._usuario_activo(usuario)
+            self._set_cell(
+                row,
+                5,
+                "Activo" if activo else "Inactivo",
+                align=Qt.AlignCenter,
+                color="#16812C" if activo else "#D92D20",
                 weight=600,
             )
             self.tabla_usuarios.setRowHeight(row, 38)
@@ -425,12 +456,16 @@ class UserFormView(QWidget):
         self.lbl_estado_edicion.setText(
             "Puedes editar nombre completo, email y rol. El ID y RUT son solo referencia."
         )
+        self._usuario_editando_activo = self._usuario_activo(usuario)
         self._set_edicion_habilitada(True)
+        self._actualizar_estado_edicion()
 
     def _limpiar_edicion(self) -> None:
         self._usuario_editando_id = None
+        self._usuario_editando_activo = True
         self.lbl_edit_id.setText("—")
         self.lbl_edit_rut.setText("—")
+        self.lbl_edit_estado.setText("—")
         self.input_edit_nombre.clear()
         self.input_edit_email.clear()
         self.cb_edit_rol.setCurrentIndex(0)
@@ -445,6 +480,8 @@ class UserFormView(QWidget):
         self.cb_edit_rol.setEnabled(habilitada)
         self.btn_guardar_edicion.setEnabled(habilitada)
         self.btn_cancelar_edicion.setEnabled(habilitada)
+        if not habilitada:
+            self.btn_estado_usuario.setEnabled(False)
 
     def _cancelar_edicion(self) -> None:
         senales_bloqueadas = self.tabla_usuarios.blockSignals(True)
@@ -490,6 +527,62 @@ class UserFormView(QWidget):
             self.btn_guardar_edicion.setText("Guardar cambios")
             self.btn_guardar_edicion.setEnabled(self._usuario_editando_id is not None)
 
+    def _cambiar_estado_usuario(self) -> None:
+        if self._usuario_editando_id is None:
+            return
+
+        if self._es_usuario_actual() and self._usuario_editando_activo:
+            QMessageBox.warning(
+                self,
+                "Acción no permitida",
+                "No puedes desactivar tu propia cuenta mientras estás en sesión.",
+            )
+            return
+
+        activar = not self._usuario_editando_activo
+        if activar:
+            titulo = "Activar usuario"
+            mensaje = (
+                "¿Activar este usuario?\n\n"
+                "El usuario podrá iniciar sesión nuevamente con sus credenciales."
+            )
+        else:
+            titulo = "Desactivar usuario"
+            mensaje = (
+                "¿Desactivar este usuario?\n\n"
+                "El usuario no podrá iniciar sesión, pero sus reportes e historial "
+                "se conservarán."
+            )
+
+        respuesta = QMessageBox.question(
+            self,
+            titulo,
+            mensaje,
+            QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+            QMessageBox.StandardButton.No,
+        )
+        if respuesta != QMessageBox.StandardButton.Yes:
+            return
+
+        user_id = self._usuario_editando_id
+        self.btn_estado_usuario.setEnabled(False)
+        self.btn_estado_usuario.setText("Actualizando...")
+        try:
+            ok, msg, actualizado = self._controller.cambiar_estado_usuario(
+                user_id,
+                activar,
+            )
+            if not ok:
+                QMessageBox.warning(self, "No fue posible cambiar el estado", msg)
+                return
+
+            QMessageBox.information(self, "Estado actualizado", msg)
+            self.refrescar(seleccionar_usuario_id=user_id)
+            if actualizado:
+                self._cargar_edicion(actualizado)
+        finally:
+            self._actualizar_estado_edicion()
+
     def _seleccionar_usuario_por_id(self, user_id: int) -> bool:
         for row in range(self.tabla_usuarios.rowCount()):
             usuario = self._usuario_desde_fila(row)
@@ -503,6 +596,41 @@ class UserFormView(QWidget):
             return int(value)
         except (TypeError, ValueError):
             return None
+
+    def _usuario_activo(self, usuario: dict) -> bool:
+        return bool(usuario.get("is_active", True))
+
+    def _actualizar_estado_edicion(self) -> None:
+        if self._usuario_editando_id is None:
+            self.lbl_edit_estado.setText("—")
+            self.btn_estado_usuario.setText("Desactivar usuario")
+            self.btn_estado_usuario.setEnabled(False)
+            return
+
+        if self._usuario_editando_activo:
+            self.lbl_edit_estado.setText("Activo")
+            self.lbl_edit_estado.setStyleSheet("color: #16812C; font-size: 13px;")
+            self.btn_estado_usuario.setText("Desactivar usuario")
+            estilizar_boton(self.btn_estado_usuario, "danger")
+            self.btn_estado_usuario.setEnabled(not self._es_usuario_actual())
+            if self._es_usuario_actual():
+                self.btn_estado_usuario.setToolTip(
+                    "No puedes desactivar tu propia cuenta mientras estás en sesión."
+                )
+            else:
+                self.btn_estado_usuario.setToolTip("")
+        else:
+            self.lbl_edit_estado.setText("Inactivo")
+            self.lbl_edit_estado.setStyleSheet("color: #D92D20; font-size: 13px;")
+            self.btn_estado_usuario.setText("Activar usuario")
+            estilizar_boton(self.btn_estado_usuario, "success")
+            self.btn_estado_usuario.setEnabled(True)
+            self.btn_estado_usuario.setToolTip("")
+
+    def _es_usuario_actual(self) -> bool:
+        if self._usuario_actual is None or self._usuario_actual.id is None:
+            return False
+        return self._usuario_editando_id == self._usuario_actual.id
 
     def _guardar(self) -> None:
         self.btn_guardar.setEnabled(False)


### PR DESCRIPTION
## Resumen

Este PR agrega la funcionalidad para que los administradores puedan activar y desactivar usuarios desde el panel desktop, sin eliminarlos de la base de datos.

La mejora permite conservar la trazabilidad de usuarios y reportes asociados, pero impide que usuarios inactivos puedan iniciar sesión.

## Cambios principales

### Base de datos

- Se agregó el campo `is_active` a la tabla `users`.
- Se agregó el índice `idx_users_is_active`.
- Se actualizó `database/seed.sql` para dejar activos a los usuarios iniciales.
- Se documentó el `ALTER TABLE` necesario para bases locales ya existentes.

### Backend

- `GET /api/v1/users/` ahora devuelve `is_active`.
- Se agregó el endpoint:

```http
PATCH /api/v1/users/{user_id}/active
```

- El endpoint permite activar o desactivar usuarios sin eliminarlos.
- El login ahora bloquea usuarios inactivos.
- El backend impide desactivar el último administrador activo.
- El backend impide quitar el rol administrador al último administrador activo.
- Las respuestas siguen siendo seguras: no exponen `password` ni `password_hash`.

### Desktop

- La tabla de usuarios ahora muestra la columna **Estado**.
- Los estados se muestran como **Activo** o **Inactivo**.
- Se agregó acción para activar/desactivar usuario desde la vista **Usuarios**.
- La acción solicita confirmación antes de ejecutarse.
- Al desactivar un usuario, este no puede iniciar sesión.
- Al activar un usuario, puede iniciar sesión nuevamente.
- El desktop bloquea que el administrador actual se desactive a sí mismo.
- Se actualiza el listado después de activar/desactivar.
- Se actualizaron los README de backend y desktop.

## Pruebas realizadas

- [x] Ejecutado `backend\.venv\Scripts\python.exe -m compileall backend\app`.
- [x] Ejecutado `desktop\.venv\Scripts\python.exe -m compileall desktop\src`.
- [x] Ejecutado `git diff --check`.
- [x] Ejecutado `ALTER TABLE` en la base local existente.
- [x] Verificado que la tabla `users` contiene `is_active`.
- [x] Verificado que los usuarios existentes quedaron activos.
- [x] Probado `GET /api/v1/users/`.
- [x] Verificado que `GET /api/v1/users/` devuelve `is_active`.
- [x] Probado `PATCH /api/v1/users/{user_id}/active` para desactivar usuario.
- [x] Probado `PATCH /api/v1/users/{user_id}/active` para activar usuario.
- [x] Verificado que un usuario inactivo no puede iniciar sesión.
- [x] Verificado que un usuario reactivado puede iniciar sesión nuevamente.
- [x] Verificado que no se puede desactivar el último administrador activo.
- [x] Verificado que no se puede quitar el rol administrador al último administrador activo.
- [x] Probado desde desktop con usuario administrador.
- [x] Verificada la columna **Estado** en la tabla de usuarios.
- [x] Verificado flujo de desactivación con confirmación.
- [x] Verificado flujo de activación con confirmación.
- [x] Verificado bloqueo de autodesactivación del administrador actual.
- [x] Verificado que crear usuario sigue funcionando.
- [x] Verificado que editar usuario sigue funcionando.

## Alcance

Este PR implementa activación/desactivación de usuarios con restricciones de seguridad básicas.

## No se modificó

- Mobile
- Emergencias
- Reportes
- Login visual desktop
- Eliminación de usuarios
- Cambio/restablecimiento de contraseña
- Edición de RUT

## Nota para bases locales existentes

Quienes ya tengan la base creada deben ejecutar manualmente:

```sql
ALTER TABLE users
ADD COLUMN is_active TINYINT(1) NOT NULL DEFAULT 1
COMMENT 'Indica si el usuario puede iniciar sesión'
AFTER role_id;

CREATE INDEX idx_users_is_active ON users(is_active);
```

Si la base se reconstruye desde cero, basta con ejecutar `database/schema.sql` y luego `database/seed.sql` actualizados.

## Limitación conocida

El backend aún no implementa autorización mediante token. Por ahora, la vista **Usuarios** se muestra solo a administradores desde desktop, y el backend protege reglas críticas como no dejar el sistema sin administradores activos.
